### PR TITLE
update CloudDirectory

### DIFF
--- a/lib/aws_codegen.ex
+++ b/lib/aws_codegen.ex
@@ -59,7 +59,7 @@ defmodule AWS.CodeGen do
     {:json, "AWS.Workspaces", "workspaces/2015-04-08", "workspaces.ex", []},
     {:rest_json, "AWS.APIGateway", "apigateway/2015-07-09", "api_gateway.ex", [:strip_trailing_slash_in_url]},
     {:rest_json, "AWS.Batch", "batch/2016-08-10", "batch.ex", []},
-    {:rest_json, "AWS.CloudDirectory", "clouddirectory/2016-05-10", "cloud_directory.ex", []},
+    {:rest_json, "AWS.CloudDirectory", "clouddirectory/2017-01-11", "cloud_directory.ex", []},
     {:rest_json, "AWS.Cognito.Sync", "cognito-sync/2014-06-30", "cognito_sync.ex", []},
     {:rest_json, "AWS.EFS", "elasticfilesystem/2015-02-01", "efs.ex", []},
     {:rest_json, "AWS.Glacier", "glacier/2012-06-01", "glacier.ex", []},


### PR DESCRIPTION
Go AWS SDK updated their `api-2.json` from 2016-05-10 to 2017-01-11 So, I was getting this error:
```
** (File.Error) could not read file "/aws-sdk-go/models/apis/clouddirectory/2016-05-10/api-2.json": no such file or directory
    (elixir) lib/file.ex:319: File.read!/1
    (aws_codegen) lib/aws_codegen/rest_json_service.ex:58: AWS.CodeGen.RestJSONService.load_context/5
    (aws_codegen) lib/aws_codegen.ex:151: AWS.CodeGen.generate_code/8
    (elixir) lib/task/supervised.ex:89: Task.Supervised.do_apply/2
    (elixir) lib/task/supervised.ex:38: Task.Supervised.reply/5
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Function: &AWS.CodeGen.generate_code/8
    Args: [:elixir, :rest_json, "AWS.CloudDirectory", "/aws-sdk-go/models/apis/clouddirectory/2016-05-10/api-2.json", "/aws-sdk-go/models/apis/clouddirectory/2016-05-10/docs-2.json", "priv", "../aws-elixir/lib/aws/cloud_directory.ex", []]
```

This PR fixes that.