### PR TITLE
[#12] Erlang rest-json spec template

### DIFF
--- a/lib/aws_codegen.ex
+++ b/lib/aws_codegen.ex
@@ -116,6 +116,20 @@ defmodule AWS.CodeGen do
     {:json, "aws_swf", "swf/2012-01-25", "aws_swf.erl", []},
     {:json, "aws_waf", "waf/2015-08-24", "aws_waf.erl", []},
     {:json, "aws_workspaces", "workspaces/2015-04-08", "aws_workspaces.erl", []},
+    {:rest_json, "aws_api_gateway", "apigateway/2015-07-09", "aws_api_gateway.erl", [:strip_trailing_slash_in_url]},
+    {:rest_json, "aws_batch", "batch/2016-08-10", "aws_batch.erl", []},
+    {:rest_json, "aws_cloud_directory", "clouddirectory/2017-01-11", "aws_cloud_directory.erl", []},
+    {:rest_json, "aws_cognito_sync", "cognito-sync/2014-06-30", "aws_cognito_sync.erl", []},
+    {:rest_json, "aws_efs", "elasticfilesystem/2015-02-01", "aws_efs.erl", []},
+    {:rest_json, "aws_glacier", "glacier/2012-06-01", "aws_glacier.erl", []},
+    {:rest_json, "aws_iot", "iot/2015-05-28", "aws_iot.erl", []},
+    {:rest_json, "aws_iot_data", "iot-data/2015-05-28", "aws_iot_data.erl", [:strip_trailing_slash_in_url]},
+    {:rest_json, "aws_lambda", "lambda/2015-03-31", "aws_lambda.erl", []},
+    {:rest_json, "aws_mobile_analytics", "mobileanalytics/2014-06-05", "aws_mobile_analytics.erl", []},
+    {:rest_json, "aws_polly", "polly/2016-06-10", "aws_polly.erl", []},
+    {:rest_json, "aws_lex_runtime", "runtime.lex/2016-11-28", "aws_lex_runtime.erl", []},
+    {:rest_json, "aws_transcoder", "elastictranscoder/2012-09-25", "aws_transcoder.erl", []},
+    {:rest_json, "aws_xray", "xray/2016-04-12", "aws_xray.erl", []},
   ]
 
   def generate(language, spec_base_path, template_base_path, output_base_path) do

--- a/lib/aws_codegen/name.ex
+++ b/lib/aws_codegen/name.ex
@@ -24,4 +24,8 @@ defmodule AWS.CodeGen.Name do
         "_#{lower_char}"
     end
   end
+
+  def upcase_first(<<first::utf8, rest::binary>>) do
+    String.upcase(<<first::utf8>>) <> rest
+  end
 end

--- a/priv/rest_json.erl.eex
+++ b/priv/rest_json.erl.eex
@@ -1,0 +1,147 @@
+%% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+%% See https://github.com/jkakar/aws-codegen for more details.
+
+<%= if context.docstring != "%% @doc" do %><%= context.docstring %><% end %>
+-module(<%= context.module_name %>).
+
+-export([<%= Enum.map(context.actions, fn(action) -> ["#{action.function_name}/#{action.arity - 1}", "#{action.function_name}/#{action.arity}"] end) |> List.flatten |> Enum.join(",\n         ") %>]).
+
+-include_lib("hackney/include/hackney_lib.hrl").
+
+%%====================================================================
+%% API
+%%====================================================================
+<%= for action <- context.actions do %>
+<%= action.docstring %><%= if action.method == "GET" do %>
+<%= action.function_name %>(Client<%= AWS.CodeGen.RestJSONService.function_parameters(action) %>)
+  when is_map(Client) ->
+    <%= action.function_name %>(Client<%= AWS.CodeGen.RestJSONService.function_parameters(action) %>, []).
+<%= action.function_name %>(Client<%= AWS.CodeGen.RestJSONService.function_parameters(action) %>, Options)
+  when is_map(Client), is_list(Options) ->
+    Path = ["<%= AWS.CodeGen.RestJSONService.Action.url_path(action) %>"],
+    SuccessStatusCode = <%= if is_nil(action.success_status_code), do: "undefined", else: inspect(action.success_status_code) %>,
+    <%= if length(action.request_header_parameters) > 0 do %> Headers0 =
+      [<%= for parameter <- Enum.drop(action.request_header_parameters, -1) do %>
+        {"<%= parameter.location_name %>", <%= parameter.code_name %>},<% end %><%= for parameter <- Enum.slice action.request_header_parameters, -1..-1 do %>
+        {"<%= parameter.location_name %>", <%= parameter.code_name %>}
+      <% end %>],
+    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
+    <% else %>Headers = [],<% end %><%= if length(action.response_header_parameters) > 0 do %>
+    case request(Client, get, Path, Headers, undefined, Options, SuccessStatusCode) of
+      {ok, Body0, {_, ResponseHeaders, _} = Response} ->
+        ResponseHeadersParams =
+          [<%= for parameter <- Enum.drop action.response_header_parameters, -1 do %>
+            {"<%= parameter.location_name %>", "<%= parameter.name %>"},<% end %><%= for parameter <- Enum.slice action.response_header_parameters, -1..-1 do %>
+            {"<%= parameter.location_name %>", "<%= parameter.name %>"}
+          <% end %>],
+        FoldFun = fun({Name, Key}, Acc) ->
+                      case lists:keyfind(Name, 1, ResponseHeaders) of
+                        false -> Acc;
+                        {_, Value} -> Acc#{Key => Value}
+                      end
+                  end,
+        Body = lists:foldl(FoldFun, Body0, ResponseHeadersParams),
+        {ok, Body, Response};
+      Result ->
+        Result
+    end.<% else %>
+    request(Client, get, Path, Headers, undefined, Options, SuccessStatusCode).<% end %>
+<% else %>
+<%= action.function_name %>(Client<%= AWS.CodeGen.RestJSONService.function_parameters(action) %>, Input) ->
+    <%= action.function_name %>(Client<%= AWS.CodeGen.RestJSONService.function_parameters(action) %>, Input, []).
+<%= action.function_name %>(Client<%= AWS.CodeGen.RestJSONService.function_parameters(action) %>, Input0, Options) ->
+    Method = <%= AWS.CodeGen.RestJSONService.Action.method(action) %>,
+    Path = ["<%= AWS.CodeGen.RestJSONService.Action.url_path(action) %>"],
+    SuccessStatusCode = <%= if is_nil(action.success_status_code), do: "undefined", else: inspect(action.success_status_code) %>,
+    <%= if length(action.request_header_parameters) > 0 do %>
+    HeadersMapping = [<%= for parameter <- Enum.drop(action.request_header_parameters, -1) do %>
+                       {"<%= parameter.location_name %>", "<%= parameter.name %>"},<% end %><%= for parameter <- Enum.slice action.request_header_parameters, -1..-1 do %>
+                       {"<%= parameter.location_name %>", "<%= parameter.name %>"}
+                     <% end %>],
+    {Headers, Input} = aws_request:build_headers(HeadersMapping, Input0),
+    <% else %>Headers = [],
+    Input = Input0,<% end %><%= if length(action.response_header_parameters) > 0 do %>
+    case request(Client, Method, Path, Headers, Input, Options, SuccessStatusCode) of
+      {ok, Body0, {_, ResponseHeaders, _} = Response} ->
+        ResponseHeadersParams =
+          [<%= for parameter <- Enum.drop action.response_header_parameters, -1 do %>
+            {"<%= parameter.location_name %>", "<%= parameter.name %>"},<% end %><%= for parameter <- Enum.slice action.response_header_parameters, -1..-1 do %>
+            {"<%= parameter.location_name %>", "<%= parameter.name %>"}
+          <% end %>],
+        FoldFun = fun({Name, Key}, Acc) ->
+                      case lists:keyfind(Name, 1, ResponseHeaders) of
+                        false -> Acc;
+                        {_, Value} -> Acc#{Key => Value}
+                      end
+                  end,
+        Body = lists:foldl(FoldFun, Body0, ResponseHeadersParams),
+        {ok, Body, Response};
+      Result ->
+        Result
+    end.<% else %>
+    request(Client, Method, Path, Headers, Input, Options, SuccessStatusCode).<% end %>
+<% end %><% end %>
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-spec request(aws_client:aws_client(), atom(), iolist(),
+              list(), map() | undefined, list(), pos_integer() | undefined) ->
+    {ok, Result, {integer(), list(), hackney:client()}} |
+    {error, Error, {integer(), list(), hackney:client()}} |
+    {error, term()} when
+    Result :: map() | undefined,
+    Error :: {binary(), binary()}.
+request(Client, Method, Path, Headers0, Input, Options, SuccessStatusCode) ->
+    Client1 = Client#{service => <<"<%= context.signing_name %>">>},
+    Host = get_host(<<"<%= context.endpoint_prefix %>">>, Client1),
+    URL = get_url(Host, Path, Client1),
+    Headers1 = [
+        {<<"Host">>, Host},
+        {<<"Content-Type">>, <<"application/x-amz-json-1.1">>}
+        | Headers0
+    ],
+    Payload = encode_payload(Input),
+    MethodBin = aws_request:method_to_binary(Method),
+    SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
+    Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),
+    handle_response(Response, SuccessStatusCode).
+
+handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode)
+  when StatusCode =:= 200;
+       StatusCode =:= 202;
+       StatusCode =:= 204;
+       StatusCode =:= SuccessStatusCode ->
+    case hackney:body(Client) of
+        {ok, <<>>} when StatusCode =:= 200;
+                        StatusCode =:= SuccessStatusCode ->
+            {ok, undefined, {StatusCode, ResponseHeaders, Client}};
+        {ok, Body} ->
+            Result = jsx:decode(Body, [return_maps]),
+            {ok, Result, {StatusCode, ResponseHeaders, Client}}
+    end;
+handle_response({ok, StatusCode, ResponseHeaders, Client}, _) ->
+    {ok, Body} = hackney:body(Client),
+    Error = jsx:decode(Body, [return_maps]),
+    Reason1 = maps:get(<<"message">>, Error, undefined),
+    Reason2 = maps:get(<<"Message">>, Error, Reason1),
+    {error, Reason2, {StatusCode, ResponseHeaders, Client}};
+handle_response({error, Reason}, _) ->
+  {error, Reason}.
+
+get_host(_EndpointPrefix, #{region := <<"local">>}) ->
+    <<"localhost">>;
+get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix, <<".">>, Region, <<".">>, Endpoint], <<"">>).
+
+get_url(Host, Path0, Client) ->
+    Proto = maps:get(proto, Client),
+    Path = erlang:iolist_to_binary(Path0),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, Path], <<"">>).
+
+-spec encode_payload(undefined | map()) -> binary().
+encode_payload(undefined) ->
+  <<>>;
+encode_payload(Input) ->
+  jsx:encode(Input).

--- a/priv/rest_json.ex.eex
+++ b/priv/rest_json.ex.eex
@@ -29,7 +29,7 @@ defmodule <%= context.module_name %> do
               {_header_name, value} -> Map.put(acc, key, value)
             end
           end)
-        
+
         {:ok, body, response}
 
       result ->
@@ -59,7 +59,7 @@ defmodule <%= context.module_name %> do
               {_header_name, value} -> Map.put(acc, key, value)
             end
           end)
-        
+
         {:ok, body, response}
 
       result ->
@@ -103,7 +103,7 @@ defmodule <%= context.module_name %> do
         {:ok, Poison.Parser.parse!(body, %{}), response}
 
       {:ok, %HTTPoison.Response{body: body}} ->
-        reason = Poison.Parser.parse!(body, %{})["message"]
+        reason = Poison.Parser.parse!(body, %{})["Message"]
         {:error, reason}
 
       {:error, %HTTPoison.Error{reason: reason}} ->
@@ -120,7 +120,7 @@ defmodule <%= context.module_name %> do
         {:ok, Poison.Parser.parse!(body, %{}), response}
 
       {:ok, %HTTPoison.Response{body: body}} ->
-        reason = Poison.Parser.parse!(body, %{})["message"]
+        reason = Poison.Parser.parse!(body, %{})["Message"]
         {:error, reason}
 
       {:error, %HTTPoison.Error{reason: reason}} ->


### PR DESCRIPTION
### Description

Add Erlang support for AWS APIs using the `rest-json` protocol. There are two related branches in the `aws-elixir` and `aws-erlang` repositories that contain the generated modules using this changes and the `aws-sdk-go` protocol definition `Release v1.33.5 (2020-07-09)`:

* [`aws-erlang`](https://github.com/aws-beam/aws-erlang/tree/erlang-rest_json-spec-template)
* [`aws-elixir`](https://github.com/aws-beam/aws-elixir/tree/erlang-rest_json-spec-template)

Fixes #12 