### PR TITLE
Update autogenerate code comments to link to the aws-beam organization

### DIFF
--- a/priv/rest_json.erl.eex
+++ b/priv/rest_json.erl.eex
@@ -1,5 +1,5 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
-%% See https://github.com/jkakar/aws-codegen for more details.
+%% See https://github.com/aws-beam/aws-codegen for more details.
 
 <%= if context.docstring != "%% @doc" do %><%= context.docstring %><% end %>
 -module(<%= context.module_name %>).

--- a/priv/rest_json.ex.eex
+++ b/priv/rest_json.ex.eex
@@ -1,5 +1,5 @@
 # WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
-# See https://github.com/jkakar/aws-codegen for more details.
+# See https://github.com/aws-beam/aws-codegen for more details.
 
 defmodule <%= context.module_name %> do
   @moduledoc """


### PR DESCRIPTION
Update the link in generated code to point to the `aws-beam` organization here on GitHub instead of to my personal fork.