### PR TITLE
[#29] Handle multi segment URI parameters

### DIFF
--- a/priv/rest_json.erl.eex
+++ b/priv/rest_json.erl.eex
@@ -90,7 +90,7 @@
     {ok, Result, {integer(), list(), hackney:client()}} |
     {error, Error, {integer(), list(), hackney:client()}} |
     {error, term()} when
-    Result :: map() | undefined,
+    Result :: map(),
     Error :: map().
 request(Client, Method, Path, Headers0, Input, Options, SuccessStatusCode) ->
     Client1 = Client#{service => <<"<%= context.signing_name %>">><%= if context.is_global do %>,
@@ -116,7 +116,7 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode)
     case hackney:body(Client) of
         {ok, <<>>} when StatusCode =:= 200;
                         StatusCode =:= SuccessStatusCode ->
-            {ok, undefined, {StatusCode, ResponseHeaders, Client}};
+            {ok, #{}, {StatusCode, ResponseHeaders, Client}};
         {ok, Body} ->
             Result = jsx:decode(Body, [return_maps]),
             {ok, Result, {StatusCode, ResponseHeaders, Client}}

--- a/priv/rest_json.ex.eex
+++ b/priv/rest_json.ex.eex
@@ -69,7 +69,7 @@ defmodule <%= context.module_name %> do
   end<% end %><% end %>
 
   @spec request(AWS.Client.t(), binary(), binary(), list(), map(), list(), pos_integer()) ::
-          {:ok, Poison.Parser.t() | nil, Poison.Response.t()}
+          {:ok, Poison.Parser.t(), Poison.Response.t()}
           | {:error, Poison.Parser.t()}
           | {:error, HTTPoison.Error.t()}
   defp request(client, method, path, headers, input, options, success_status_code) do
@@ -110,7 +110,7 @@ defmodule <%= context.module_name %> do
   defp perform_request(method, url, payload, headers, options, success_status_code) do
     case HTTPoison.request(method, url, payload, headers, options) do
       {:ok, %HTTPoison.Response{status_code: ^success_status_code, body: ""} = response} ->
-        {:ok, nil, response}
+        {:ok, %{}, response}
 
       {:ok, %HTTPoison.Response{status_code: ^success_status_code, body: body} = response} ->
         {:ok, Poison.Parser.parse!(body, %{}), response}

--- a/priv/rest_xml.erl.eex
+++ b/priv/rest_xml.erl.eex
@@ -121,7 +121,7 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode)
     case hackney:body(Client) of
         {ok, <<>>} when StatusCode =:= 200;
                         StatusCode =:= SuccessStatusCode ->
-            {ok, undefined, {StatusCode, ResponseHeaders, Client}};
+            {ok, #{}, {StatusCode, ResponseHeaders, Client}};
         {ok, Body} ->
             Result = aws_util:decode_xml(Body),
             {ok, Result, {StatusCode, ResponseHeaders, Client}}

--- a/priv/rest_xml.ex.eex
+++ b/priv/rest_xml.ex.eex
@@ -69,7 +69,7 @@ defmodule <%= context.module_name %> do
   end<% end %><% end %>
 
   @spec request(AWS.Client.t(), binary(), binary(), list(), map(), list(), pos_integer()) ::
-          {:ok, Poison.Parser.t() | nil, Poison.Response.t()}
+          {:ok, Poison.Parser.t(), Poison.Response.t()}
           | {:error, Poison.Parser.t()}
           | {:error, HTTPoison.Error.t()}
   defp request(client, method, path, headers, input, options, success_status_code) do
@@ -110,7 +110,7 @@ defmodule <%= context.module_name %> do
   defp perform_request(method, url, payload, headers, options, success_status_code) do
     case HTTPoison.request(method, url, payload, headers, options) do
       {:ok, %HTTPoison.Response{status_code: ^success_status_code, body: ""} = response} ->
-        {:ok, nil, response}
+        {:ok, %{}, response}
 
       {:ok, %HTTPoison.Response{status_code: ^success_status_code, body: body} = response} ->
         {:ok, AWS.Util.decode_xml(body), response}


### PR DESCRIPTION
### Description

* Handle URI parameters that can have multiple segments.
* Return an empty map instead of `undefined` or `nil` when the response body is empty in REST based protocols.

Changes in generated projects:
- [Elixir](https://github.com/aws-beam/aws-elixir/compare/master...aws-beam:handle-multi-segment-uri-parameters?expand=1)
- [Erlang](https://github.com/aws-beam/aws-erlang/compare/master...aws-beam:handle-multi-segment-uri-parameters?expand=1)

Fixes #29 