### PR TITLE
[#25] Generate all missing services

### DIFF
--- a/lib/aws_codegen.ex
+++ b/lib/aws_codegen.ex
@@ -1,286 +1,77 @@
 defmodule AWS.CodeGen do
-
-  @elixir_services [
-    {:json, "AWS.AppStream", "appstream/2016-12-01", "appstream.ex", []},
-    {:json, "AWS.AppAutoScaling", "application-autoscaling/2016-02-06", "app_autoscaling.ex", []},
-    {:json, "AWS.Budgets", "budgets/2016-10-20", "budgets.ex", []},
-    {:json, "AWS.CertificateManager", "acm/2015-12-08", "certificate_manager.ex", []},
-    {:json, "AWS.CloudHSM", "cloudhsm/2014-05-30", "cloud_hsm.ex", []},
-    {:json, "AWS.CloudTrail", "cloudtrail/2013-11-01", "cloud_trail.ex", []},
-    {:json, "AWS.CloudWatch.Events", "events/2015-10-07", "cloudwatch_events.ex", []},
-    {:json, "AWS.CodeBuild", "codebuild/2016-10-06", "code_build.ex", []},
-    {:json, "AWS.CodeCommit", "codecommit/2015-04-13", "code_commit.ex", []},
-    {:json, "AWS.CodeDeploy", "codedeploy/2014-10-06", "code_deploy.ex", []},
-    {:json, "AWS.CodePipeline", "codepipeline/2015-07-09", "code_pipeline.ex", []},
-    {:json, "AWS.Cognito", "cognito-identity/2014-06-30", "cognito.ex", []},
-    {:json, "AWS.Cognito.IdentityProvider", "cognito-idp/2016-04-18", "cognito_identity_provider.ex", []},
-    {:json, "AWS.Config", "config/2014-11-12", "config.ex", []},
-    {:json, "AWS.CostAndUsageReport", "cur/2017-01-06", "cost_and_usage_report.ex", []},
-    {:json, "AWS.DataPipeline", "datapipeline/2012-10-29", "data_pipeline.ex", []},
-    {:json, "AWS.DeviceFarm", "devicefarm/2015-06-23", "device_farm.ex", []},
-    {:json, "AWS.DirectConnect", "directconnect/2012-10-25", "direct_connect.ex", []},
-    {:json, "AWS.DirectoryService", "ds/2015-04-16", "directory_service.ex", []},
-    {:json, "AWS.Discovery", "discovery/2015-11-01", "discovery.ex", []},
-    {:json, "AWS.DynamoDB", "dynamodb/2012-08-10", "dynamodb.ex", []},
-    {:json, "AWS.DynamoDB.Streams", "streams.dynamodb/2012-08-10", "dynamodb_streams.ex", []},
-    {:json, "AWS.DMS", "dms/2016-01-01", "dms.ex", []},
-    {:json, "AWS.ECR", "ecr/2015-09-21", "ecr.ex", []},
-    {:json, "AWS.ECS", "ecs/2014-11-13", "ecs.ex", []},
-    {:json, "AWS.EMR", "elasticmapreduce/2009-03-31", "emr.ex", []},
-    {:json, "AWS.GameLift", "gamelift/2015-10-01", "gamelift.ex", []},
-    {:json, "AWS.Health", "health/2016-08-04", "health.ex", []},
-    {:json, "AWS.Inspector", "inspector/2016-02-16", "inspector.ex", []},
-    {:json, "AWS.Kinesis", "kinesis/2013-12-02", "kinesis.ex", []},
-    {:json, "AWS.Kinesis.Analytics", "kinesisanalytics/2015-08-14", "kinesis_analytics.ex", []},
-    {:json, "AWS.Kinesis.Firehose", "firehose/2015-08-04", "kinesis_firehose.ex", []},
-    {:json, "AWS.KMS", "kms/2014-11-01", "kms.ex", []},
-    {:json, "AWS.Lightsail", "lightsail/2016-11-28", "lightsail.ex", []},
-    {:json, "AWS.Logs", "logs/2014-03-28", "logs.ex", []},
-    {:json, "AWS.MachineLearning", "machinelearning/2014-12-12", "machine_learning.ex", []},
-    {:json, "AWS.Marketplace.CommerceAnalytics", "marketplacecommerceanalytics/2015-07-01", "marketplace_commerce_analytics.ex", []},
-    {:json, "AWS.Marketplace.Metering", "meteringmarketplace/2016-01-14", "marketplace_metering.ex", []},
-    {:json, "AWS.MechanicalTurk", "mturk-requester/2017-01-17", "mechanical_turk.ex", []},
-    {:json, "AWS.OpsWorks", "opsworks/2013-02-18", "ops_works.ex", []},
-    {:json, "AWS.OpsWorks.ChefAutomate", "opsworkscm/2016-11-01", "ops_works_chef_automate.ex", []},
-    {:json, "AWS.Organizations", "organizations/2016-11-28", "organizations.ex", []},
-    {:json, "AWS.Rekognition", "rekognition/2016-06-27", "rekognition.ex", []},
-    {:json, "AWS.Route53.Domains", "route53domains/2014-05-15", "route53_domains.ex", []},
-    {:json, "AWS.SecretsManager", "secretsmanager/2017-10-17", "secrets_manager.ex", []},
-    {:json, "AWS.ServiceCatalog", "servicecatalog/2015-12-10", "service_catalog.ex", []},
-    {:json, "AWS.Shield", "shield/2016-06-02", "shield.ex", []},
-    {:json, "AWS.Snowball", "snowball/2016-06-30", "snowball.ex", []},
-    {:json, "AWS.StepFunctions", "states/2016-11-23", "step_functions.ex", []},
-    {:json, "AWS.StorageGateway", "storagegateway/2013-06-30", "storage_gateway.ex", []},
-    {:json, "AWS.Support", "support/2013-04-15", "support.ex", []},
-    {:json, "AWS.SMS", "sms/2016-10-24", "sms.ex", []},
-    {:json, "AWS.SSM", "ssm/2014-11-06", "ssm.ex", []},
-    {:json, "AWS.SWF", "swf/2012-01-25", "swf.ex", []},
-    {:json, "AWS.WAF", "waf/2015-08-24", "waf.ex", []},
-    {:json, "AWS.WAF.Regional", "waf-regional/2016-11-28", "waf_regional.ex", []},
-    {:json, "AWS.Workspaces", "workspaces/2015-04-08", "workspaces.ex", []},
-    {:rest_json, "AWS.APIGateway", "apigateway/2015-07-09", "api_gateway.ex", []},
-    {:rest_json, "AWS.Batch", "batch/2016-08-10", "batch.ex", []},
-    {:rest_json, "AWS.CloudDirectory", "clouddirectory/2017-01-11", "cloud_directory.ex", []},
-    {:rest_json, "AWS.Cognito.Sync", "cognito-sync/2014-06-30", "cognito_sync.ex", []},
-    {:rest_json, "AWS.Connect", "connect/2017-08-08", "connect.ex", []},
-    {:rest_json, "AWS.EFS", "elasticfilesystem/2015-02-01", "efs.ex", []},
-    {:rest_json, "AWS.Glacier", "glacier/2012-06-01", "glacier.ex", []},
-    {:rest_json, "AWS.IoT", "iot/2015-05-28", "iot.ex", []},
-    {:rest_json, "AWS.IoT.DataPlane", "iot-data/2015-05-28", "iot_data.ex", []},
-    {:rest_json, "AWS.Lambda", "lambda/2015-03-31", "lambda.ex", []},
-    {:rest_json, "AWS.MobileAnalytics", "mobileanalytics/2014-06-05", "mobile_analytics.ex", []},
-    {:rest_json, "AWS.Pinpoint", "pinpoint/2016-12-01", "pinpoint.ex", []},
-    {:rest_json, "AWS.Polly", "polly/2016-06-10", "polly.ex", []},
-    {:rest_json, "AWS.LexRuntime", "runtime.lex/2016-11-28", "lex_runtime.ex", []},
-    {:rest_json, "AWS.Transcoder", "elastictranscoder/2012-09-25", "transcoder.ex", []},
-    {:rest_json, "AWS.XRay", "xray/2016-04-12", "xray.ex", []},
-    {:rest_xml, "AWS.Cloudfront", "cloudfront/2020-05-31", "cloudfront.ex", []},
-    {:rest_xml, "AWS.Route53", "route53/2013-04-01", "route53.ex", []},
-    {:rest_xml, "AWS.S3", "s3/2006-03-01", "s3.ex", []},
-    {:rest_xml, "AWS.S3Control", "s3control/2018-08-20", "s3control.ex", []},
-    {:query, "AWS.Autoscaling", "autoscaling/2011-01-01", "autoscaling.ex", []},
-    {:query, "AWS.CloudFormation", "cloudformation/2010-05-15", "cloud_formation.ex", []},
-    {:query, "AWS.CloudSearch", "cloudsearch/2013-01-01", "cloud_search.ex", []},
-    {:query, "AWS.DocDB", "docdb/2014-10-31", "doc_db.ex", []},
-    {:query, "AWS.ElastiCache", "elasticache/2015-02-02", "elasticache.ex", []},
-    {:query, "AWS.ElasticBeanstalk", "elasticbeanstalk/2010-12-01", "elastic_beanstalk.ex", []},
-    {:query, "AWS.ElasticLoadBalancing", "elasticloadbalancing/2012-06-01", "elastic_load_balancing.ex", []},
-    {:query, "AWS.ElasticLoadBalancingV2", "elasticloadbalancingv2/2015-12-01", "elastic_load_balancing_v2.ex", []},
-    {:query, "AWS.Email", "email/2010-12-01", "email.ex", []},
-    {:query, "AWS.IAM", "iam/2010-05-08", "iam.ex", []},
-    {:query, "AWS.ImportExport", "importexport/2010-06-01", "import_export.ex", []},
-    {:query, "AWS.Monitoring", "monitoring/2010-08-01", "monitoring.ex", []},
-    {:query, "AWS.Neptune", "neptune/2014-10-31", "neptune.ex", []},
-    {:query, "AWS.RDS", "rds/2014-10-31", "rds.ex", []},
-    {:query, "AWS.Redshift", "redshift/2012-12-01", "redshift.ex", []},
-    {:query, "AWS.SDB", "sdb/2009-04-15", "sdb.ex", []},
-    {:query, "AWS.SNS", "sns/2010-03-31", "sns.ex", []},
-    {:query, "AWS.SQS", "sqs/2012-11-05", "sqs.ex", []},
-    {:query, "AWS.STS", "sts/2011-06-15", "sts.ex", []},
-  ]
-
-  @erlang_services [
-    {:json, "aws_appstream", "appstream/2016-12-01", "aws_appstream.erl", []},
-    {:json, "aws_app_autoscaling", "application-autoscaling/2016-02-06", "aws_app_autoscaling.erl", []},
-    {:json, "aws_budgets", "budgets/2016-10-20", "aws_budgets.erl", []},
-    {:json, "aws_certificate_manager", "acm/2015-12-08", "aws_certificate_manager.erl", []},
-    {:json, "aws_cloud_hsm", "cloudhsm/2014-05-30", "aws_cloud_hsm.erl", []},
-    {:json, "aws_cloud_trail", "cloudtrail/2013-11-01", "aws_cloud_trail.erl", []},
-    {:json, "aws_cloudwatch_events", "events/2015-10-07", "aws_cloudwatch_events.erl", []},
-    {:json, "aws_code_build", "codebuild/2016-10-06", "aws_code_build.erl", []},
-    {:json, "aws_code_commit", "codecommit/2015-04-13", "aws_code_commit.erl", []},
-    {:json, "aws_code_deploy", "codedeploy/2014-10-06", "aws_code_deploy.erl", []},
-    {:json, "aws_code_pipeline", "codepipeline/2015-07-09", "aws_code_pipeline.erl", []},
-    {:json, "aws_cognito", "cognito-identity/2014-06-30", "aws_cognito.erl", []},
-    {:json, "aws_cognito_idp", "cognito-idp/2016-04-18", "aws_cognito_idp.erl", []},
-    {:json, "aws_config", "config/2014-11-12", "aws_config.erl", []},
-    {:json, "aws_cost_and_usage_report", "cur/2017-01-06", "aws_cost_and_usage_report.erl", []},
-    {:json, "aws_data_pipeline", "datapipeline/2012-10-29", "aws_data_pipeline.erl", []},
-    {:json, "aws_device_farm", "devicefarm/2015-06-23", "aws_device_farm.erl", []},
-    {:json, "aws_direct_connect", "directconnect/2012-10-25", "aws_direct_connect.erl", []},
-    {:json, "aws_directory_service", "ds/2015-04-16", "aws_directory_service.erl", []},
-    {:json, "aws_discovery", "discovery/2015-11-01", "aws_discovery.erl", []},
-    {:json, "aws_dynamodb", "dynamodb/2012-08-10", "aws_dynamodb.erl", []},
-    {:json, "aws_dynamodb_streams", "streams.dynamodb/2012-08-10", "aws_dynamodb_streams.erl", []},
-    {:json, "aws_dms", "dms/2016-01-01", "aws_dms.erl", []},
-    {:json, "aws_ecr", "ecr/2015-09-21", "aws_ecr.erl", []},
-    {:json, "aws_ecs", "ecs/2014-11-13", "aws_ecs.erl", []},
-    {:json, "aws_emr", "elasticmapreduce/2009-03-31", "aws_emr.erl", []},
-    {:json, "aws_gamelift", "gamelift/2015-10-01", "aws_gamelift.erl", []},
-    {:json, "aws_health", "health/2016-08-04", "aws_health.erl", []},
-    {:json, "aws_inspector", "inspector/2016-02-16", "aws_inspector.erl", []},
-    {:json, "aws_kinesis", "kinesis/2013-12-02", "aws_kinesis.erl", []},
-    {:json, "aws_kinesis_analytics", "kinesisanalytics/2015-08-14", "aws_kinesis_analytics.erl", []},
-    {:json, "aws_kinesis_firehose", "firehose/2015-08-04", "aws_kinesis_firehose.erl", []},
-    {:json, "aws_kms", "kms/2014-11-01", "aws_kms.erl", []},
-    {:json, "aws_lightsail", "lightsail/2016-11-28", "aws_lightsail.erl", []},
-    {:json, "aws_logs", "logs/2014-03-28", "aws_logs.erl", []},
-    {:json, "aws_machine_learning", "machinelearning/2014-12-12", "aws_machine_learning.erl", []},
-    {:json, "aws_marketplace_commerce_analytics", "marketplacecommerceanalytics/2015-07-01", "aws_marketplace_commerce_analytics.erl", []},
-    {:json, "aws_marketplace_metering", "meteringmarketplace/2016-01-14", "aws_marketplace_metering.erl", []},
-    {:json, "aws_mechanical_turk", "mturk-requester/2017-01-17", "aws_mechanical_turk.erl", []},
-    {:json, "aws_ops_works", "opsworks/2013-02-18", "aws_ops_works.erl", []},
-    {:json, "aws_ops_works_chef_automate", "opsworkscm/2016-11-01", "aws_ops_works_chef_automate.erl", []},
-    {:json, "aws_organizations", "organizations/2016-11-28", "aws_organizations.erl", []},
-    {:json, "aws_rekognition", "rekognition/2016-06-27", "aws_rekognition.erl", []},
-    {:json, "aws_route53_domains", "route53domains/2014-05-15", "aws_route53_domains.erl", []},
-    {:json, "aws_secrets_manager", "secretsmanager/2017-10-17", "aws_secrets_manager.erl", []},
-    {:json, "aws_service_catalog", "servicecatalog/2015-12-10", "aws_service_catalog.erl", []},
-    {:json, "aws_shield", "shield/2016-06-02", "aws_shield.erl", []},
-    {:json, "aws_snowball", "snowball/2016-06-30", "aws_snowball.erl", []},
-    {:json, "aws_step_functions", "states/2016-11-23", "aws_step_functions.erl", []},
-    {:json, "aws_storage_gateway", "storagegateway/2013-06-30", "aws_storage_gateway.erl", []},
-    {:json, "aws_support", "support/2013-04-15", "aws_support.erl", []},
-    {:json, "aws_sms", "sms/2016-10-24", "aws_sms.erl", []},
-    {:json, "aws_ssm", "ssm/2014-11-06", "aws_ssm.erl", []},
-    {:json, "aws_swf", "swf/2012-01-25", "aws_swf.erl", []},
-    {:json, "aws_waf", "waf/2015-08-24", "aws_waf.erl", []},
-    {:json, "aws_waf_regional", "waf-regional/2016-11-28", "aws_waf_regional.erl", []},
-    {:json, "aws_workspaces", "workspaces/2015-04-08", "aws_workspaces.erl", []},
-    {:rest_json, "aws_api_gateway", "apigateway/2015-07-09", "aws_api_gateway.erl", []},
-    {:rest_json, "aws_batch", "batch/2016-08-10", "aws_batch.erl", []},
-    {:rest_json, "aws_cloud_directory", "clouddirectory/2017-01-11", "aws_cloud_directory.erl", []},
-    {:rest_json, "aws_cognito_sync", "cognito-sync/2014-06-30", "aws_cognito_sync.erl", []},
-    {:rest_json, "aws_connect", "connect/2017-08-08", "aws_connect.erl", []},
-    {:rest_json, "aws_efs", "elasticfilesystem/2015-02-01", "aws_efs.erl", []},
-    {:rest_json, "aws_glacier", "glacier/2012-06-01", "aws_glacier.erl", []},
-    {:rest_json, "aws_iot", "iot/2015-05-28", "aws_iot.erl", []},
-    {:rest_json, "aws_iot_data", "iot-data/2015-05-28", "aws_iot_data.erl", []},
-    {:rest_json, "aws_lambda", "lambda/2015-03-31", "aws_lambda.erl", []},
-    {:rest_json, "aws_mobile_analytics", "mobileanalytics/2014-06-05", "aws_mobile_analytics.erl", []},
-    {:rest_json, "aws_pinpoint", "pinpoint/2016-12-01", "aws_pinpoint.erl", []},
-    {:rest_json, "aws_polly", "polly/2016-06-10", "aws_polly.erl", []},
-    {:rest_json, "aws_lex_runtime", "runtime.lex/2016-11-28", "aws_lex_runtime.erl", []},
-    {:rest_json, "aws_transcoder", "elastictranscoder/2012-09-25", "aws_transcoder.erl", []},
-    {:rest_json, "aws_xray", "xray/2016-04-12", "aws_xray.erl", []},
-    {:rest_xml, "aws_cloudfront", "cloudfront/2020-05-31", "aws_cloudfront.erl", []},
-    {:rest_xml, "aws_route53", "route53/2013-04-01", "aws_route53.erl", []},
-    {:rest_xml, "aws_s3", "s3/2006-03-01", "aws_s3.erl", []},
-    {:rest_xml, "aws_s3control", "s3control/2018-08-20", "aws_s3control.erl", []},
-    {:query, "aws_autoscaling", "autoscaling/2011-01-01", "aws_autoscaling.erl", []},
-    {:query, "aws_cloudformation", "cloudformation/2010-05-15", "aws_cloudformation.erl", []},
-    {:query, "aws_cloudsearch", "cloudsearch/2013-01-01", "aws_cloudsearch.erl", []},
-    {:query, "aws_docdb", "docdb/2014-10-31", "aws_docdb.erl", []},
-    {:query, "aws_elasticache", "elasticache/2015-02-02", "aws_elasticache.erl", []},
-    {:query, "aws_elasticbeanstalk", "elasticbeanstalk/2010-12-01", "aws_elasticbeanstalk.erl", []},
-    {:query, "aws_elasticloadbalancing", "elasticloadbalancing/2012-06-01", "aws_elasticloadbalancing.erl", []},
-    {:query, "aws_elasticloadbalancingv2", "elasticloadbalancingv2/2015-12-01", "aws_elasticloadbalancingv2.erl", []},
-    {:query, "aws_email", "email/2010-12-01", "aws_email.erl", []},
-    {:query, "aws_iam", "iam/2010-05-08", "aws_iam.erl", []},
-    {:query, "aws_importexport", "importexport/2010-06-01", "aws_importexport.erl", []},
-    {:query, "aws_monitoring", "monitoring/2010-08-01", "aws_monitoring.erl", []},
-    {:query, "aws_neptune", "neptune/2014-10-31", "aws_neptune.erl", []},
-    {:query, "aws_rds", "rds/2014-10-31", "aws_rds.erl", []},
-    {:query, "aws_redshift", "redshift/2012-12-01", "aws_redshift.erl", []},
-    {:query, "aws_sdb", "sdb/2009-04-15", "aws_sdb.erl", []},
-    {:query, "aws_sns", "sns/2010-03-31", "aws_sns.erl", []},
-    {:query, "aws_sqs", "sqs/2012-11-05", "aws_sqs.erl", []},
-    {:query, "aws_sts", "sts/2011-06-15", "aws_sts.erl", []},
-  ]
+  alias AWS.CodeGen.Spec
 
   @configuration %{
-    :api_specs => %{
-      :elixir => @elixir_services,
-      :erlang => @erlang_services
+    :json => %{
+      :module => AWS.CodeGen.PostService,
+      :template => %{
+        :elixir => "post.ex.eex",
+        :erlang => "post.erl.eex"
+      }
     },
-    :protocols => %{
-      :json => %{
-        :module => AWS.CodeGen.PostService,
-        :template => %{
-          :elixir => "post.ex.eex",
-          :erlang => "post.erl.eex"
-        }
-      },
-      :rest_json => %{
-        :module => AWS.CodeGen.RestService,
-        :template => %{
-          :elixir => "rest.ex.eex",
-          :erlang => "rest.erl.eex"
-        }
-      },
-      :query => %{
-        :module => AWS.CodeGen.PostService,
-        :template => %{
-          :elixir => "post.ex.eex",
-          :erlang => "post.erl.eex"
-        }
-      },
-      :rest_xml => %{
-        :module => AWS.CodeGen.RestService,
-        :template => %{
-          :elixir => "rest.ex.eex",
-          :erlang => "rest.erl.eex"
-        }
+    :rest_json => %{
+      :module => AWS.CodeGen.RestService,
+      :template => %{
+        :elixir => "rest.ex.eex",
+        :erlang => "rest.erl.eex"
+      }
+    },
+    :query => %{
+      :module => AWS.CodeGen.PostService,
+      :template => %{
+        :elixir => "post.ex.eex",
+        :erlang => "post.erl.eex"
+      }
+    },
+    :rest_xml => %{
+      :module => AWS.CodeGen.RestService,
+      :template => %{
+        :elixir => "rest.ex.eex",
+        :erlang => "rest.erl.eex"
       }
     }
   }
 
   def generate(language, spec_base_path, template_base_path, output_base_path) do
     endpoints_spec = get_endpoints_spec(spec_base_path)
-    tasks = Enum.map(@configuration[:api_specs][language],
-      fn({protocol, module_name, spec_path, output_filename, options}) ->
-        api_spec_path = make_spec_path(spec_base_path, spec_path, "api-2.json")
-        doc_spec_path = make_spec_path(spec_base_path, spec_path, "docs-2.json")
-        output_path = Path.join(output_base_path, output_filename)
-        args = [language, protocol, module_name, endpoints_spec,
-                api_spec_path, doc_spec_path,
-                template_base_path, output_path, options]
+    tasks = Enum.map(api_specs(spec_base_path, language),
+      fn(spec) ->
+        output_path = Path.join(output_base_path, spec.filename)
+        args = [spec, language, endpoints_spec, template_base_path, output_path]
         Task.async(AWS.CodeGen, :generate_code, args)
       end)
     Enum.each(tasks, fn(task) -> Task.await(task) end)
   end
 
-  def generate_code(
-    language, protocol, module_name, endpoints_spec,
-    api_spec_path, doc_spec_path,
-    template_base_path, output_path, options
-  ) do
-    template = @configuration[:protocols][protocol][:template][language]
-    protocol_service = @configuration[:protocols][protocol][:module]
-    template_path = Path.join(template_base_path, template)
-    args = [language, module_name, endpoints_spec,
-            parse_spec(api_spec_path), parse_spec(doc_spec_path),
-            options]
-    context = apply(protocol_service, :load_context, args)
-    code = apply(protocol_service, :render, [context, template_path])
-    IO.puts(["Writing ", module_name, " to ", output_path])
-    File.write(output_path, code)
+  def generate_code(spec, language, endpoints_spec, template_base_path, output_path) do
+    template = @configuration[spec.protocol][:template][language]
+    if not is_nil(template) do
+      protocol_service = @configuration[spec.protocol][:module]
+      template_path = Path.join(template_base_path, template)
+      args = [language, spec.module_name, endpoints_spec, spec.api, spec.doc]
+      context = apply(protocol_service, :load_context, args)
+      code = apply(protocol_service, :render, [context, template_path])
+      IO.puts(["Writing ", spec.module_name, " to ", output_path])
+      File.write(output_path, code)
+    else
+      IO.puts("Failed to generate #{spec.module_name}, protocol #{Atom.to_string(spec.protocol)}")
+    end
   end
 
-  defp make_spec_path(spec_base_path, spec_path, filename) do
-    spec_base_path |> Path.join(spec_path) |> Path.join(filename)
+  defp api_specs(base_path, language) do
+    search_path = Path.join(base_path, "*/*")
+    IO.puts("Parsing specs in #{search_path}")
+    for path <- Path.wildcard(search_path) do
+      Spec.parse(path, language)
+    end
   end
 
   defp get_endpoints_spec(base_path) do
     Path.join([base_path, "..", "endpoints", "endpoints.json"])
-    |> parse_spec
+    |> Spec.parse_json
     |> get_in(["partitions"])
     |> Enum.filter(fn(x) -> x["partition"] == "aws" end)
     |> List.first
-  end
-
-  defp parse_spec(path) do
-    path |> File.read! |> Poison.Parser.parse!(%{})
   end
 
 end

--- a/lib/aws_codegen/post_service.ex
+++ b/lib/aws_codegen/post_service.ex
@@ -57,11 +57,11 @@ defmodule AWS.CodeGen.PostService do
   that can be used to generate code for an AWS service.  `language` must be
   `:elixir` or `:erlang`.
   """
-  def load_context(language, module_name, endpoints_spec, api_spec, doc_spec, _options) do
+  def load_context(language, module_name, endpoints_spec, api_spec, doc_spec) do
     actions = collect_actions(language, api_spec, doc_spec)
     endpoint_prefix = api_spec["metadata"]["endpointPrefix"]
     endpoint_info = endpoints_spec["services"][endpoint_prefix]
-    is_global = not Map.get(endpoint_info, "isRegionalized", true)
+    is_global = not is_nil(endpoint_info) and not Map.get(endpoint_info, "isRegionalized", true)
     credential_scope = if is_global do
       endpoint_info["endpoints"]["aws-global"]["credentialScope"]["region"]
     else

--- a/lib/aws_codegen/rest_service.ex
+++ b/lib/aws_codegen/rest_service.ex
@@ -13,7 +13,6 @@ defmodule AWS.CodeGen.RestService do
               is_global: false,
               json_version: nil,
               module_name: nil,
-              options: [],
               protocol: nil,
               signing_name: nil,
               target_prefix: nil
@@ -107,12 +106,12 @@ defmodule AWS.CodeGen.RestService do
   that can be used to generate code for an AWS service.  `language` must be
   `:elixir` or `:erlang`.
   """
-  def load_context(language, module_name, endpoints_spec, api_spec, doc_spec, options) do
+  def load_context(language, module_name, endpoints_spec, api_spec, doc_spec) do
     actions = collect_actions(language, api_spec, doc_spec)
     protocol = api_spec["metadata"]["protocol"]
     endpoint_prefix = api_spec["metadata"]["endpointPrefix"]
     endpoint_info = endpoints_spec["services"][endpoint_prefix]
-    is_global = not Map.get(endpoint_info, "isRegionalized", true)
+    is_global = not is_nil(endpoint_info) and not Map.get(endpoint_info, "isRegionalized", true)
     credential_scope = if is_global do
       endpoint_info["endpoints"]["aws-global"]["credentialScope"]["region"]
     else
@@ -132,7 +131,6 @@ defmodule AWS.CodeGen.RestService do
              is_global: is_global,
              json_version: api_spec["metadata"]["jsonVersion"],
              module_name: module_name,
-             options: options,
              protocol: api_spec["metadata"]["protocol"],
              signing_name: signing_name,
              target_prefix: api_spec["metadata"]["targetPrefix"]}

--- a/lib/aws_codegen/spec.ex
+++ b/lib/aws_codegen/spec.ex
@@ -1,0 +1,81 @@
+defmodule AWS.CodeGen.Spec do
+  defstruct protocol: nil,
+    module_name: nil,
+    filename: nil,
+    api: nil,
+    doc: nil
+
+  def parse(path, language) do
+    api = path |> Path.join("api-2.json") |> parse_json
+    protocol = api["metadata"]["protocol"]
+    |> String.replace("-", "_")
+    |> String.to_atom
+    module_name = module_name(api, language)
+    filename = filename(module_name, language)
+    %AWS.CodeGen.Spec{
+      protocol: protocol,
+      module_name: module_name,
+      filename: filename,
+      api: path |> Path.join("api-2.json") |> parse_json,
+      doc: path |> Path.join("docs-2.json") |> parse_json
+    }
+  end
+
+  def parse_json(path) do
+    if File.exists?(path) do
+      path |> File.read! |> Poison.Parser.parse!(%{})
+    end
+  end
+
+  defp module_name(api, language) do
+    service_name = case api["metadata"]["serviceId"] do
+                     nil -> api["metadata"]["endpointPrefix"]
+                     service_id -> service_id
+                   end
+    case language do
+      :elixir ->
+        service_name = service_name
+        |> String.replace(" ", "")
+        |> String.replace("-sync", ".Sync")
+        |> AWS.CodeGen.Name.upcase_first
+        "AWS.#{service_name}"
+      :erlang ->
+        service_name = service_name
+        |> String.replace(" ", "_")
+        |> String.replace(".", "_")
+        |> String.downcase
+        |> AWS.CodeGen.Name.to_snake_case
+        "aws_#{service_name}"
+    end
+  end
+
+  defp filename(module_name, :elixir) do
+    module_name = module_name
+    |> String.replace("AWS.", "")
+    |> String.replace("SMS", "Sms")
+    |> String.replace("WAF", "Waf")
+    |> String.replace("API", "Api")
+    |> String.replace("SES", "Ses")
+    |> String.replace("HSM", "Hsm")
+    |> String.replace("EC2", "Ec2")
+    |> String.replace("ElastiCache", "Elasticache")
+    |> String.replace("FSx", "Fsx")
+    |> String.replace("IoT", "Iot")
+    |> String.replace("MTurk", "Mturk")
+    |> String.replace("QLDB", "Qldb")
+    |> String.replace("DB", "Db")
+    |> String.replace("RDS", "Rds")
+    |> String.replace("A2I", "A2i")
+    |> String.replace("XRay", "Xray")
+    |> String.replace(".", "")
+    name = if module_name == String.upcase(module_name) do
+      String.downcase(module_name)
+    else
+      AWS.CodeGen.Name.to_snake_case(module_name)
+    end
+    "#{name}.ex"
+  end
+  defp filename(module_name, :erlang) do
+    "#{module_name}.erl"
+  end
+end

--- a/lib/aws_codegen/spec.ex
+++ b/lib/aws_codegen/spec.ex
@@ -33,6 +33,9 @@ defmodule AWS.CodeGen.Spec do
                      service_id -> service_id
                    end
     |> String.replace("-sync", "Sync")
+    |> String.replace("dynamodb", "DynamoDB")
+    |> String.replace("api.pricing", "API.Pricing")
+    |> String.replace("entitlement.marketplace", "Entitlement.Marketplace")
     case language do
       :elixir ->
         service_name = service_name
@@ -59,6 +62,7 @@ defmodule AWS.CodeGen.Spec do
     |> String.replace("SES", "Ses")
     |> String.replace("HSM", "Hsm")
     |> String.replace("EC2", "Ec2")
+    |> String.replace("DynamoDB", "Dynamodb")
     |> String.replace("ElastiCache", "Elasticache")
     |> String.replace("FSx", "Fsx")
     |> String.replace("IoT", "Iot")

--- a/lib/aws_codegen/spec.ex
+++ b/lib/aws_codegen/spec.ex
@@ -1,4 +1,7 @@
 defmodule AWS.CodeGen.Spec do
+  @moduledoc """
+  Parse and process the specfication for an AWS service.
+  """
   defstruct protocol: nil,
     module_name: nil,
     filename: nil,

--- a/lib/aws_codegen/spec.ex
+++ b/lib/aws_codegen/spec.ex
@@ -33,6 +33,8 @@ defmodule AWS.CodeGen.Spec do
                      service_id -> service_id
                    end
     |> String.replace("-sync", "Sync")
+    |> String.replace("Route 53", "Route53")
+    |> String.replace(~r/ Service$/, "")
     |> String.replace("dynamodb", "DynamoDB")
     |> String.replace("api.pricing", "API.Pricing")
     |> String.replace("entitlement.marketplace", "Entitlement.Marketplace")

--- a/lib/aws_codegen/spec.ex
+++ b/lib/aws_codegen/spec.ex
@@ -32,11 +32,12 @@ defmodule AWS.CodeGen.Spec do
                      nil -> api["metadata"]["endpointPrefix"]
                      service_id -> service_id
                    end
+    |> String.replace("-sync", "Sync")
     case language do
       :elixir ->
         service_name = service_name
+        |> String.replace(" connections", " Connections")
         |> String.replace(" ", "")
-        |> String.replace("-sync", ".Sync")
         |> AWS.CodeGen.Name.upcase_first
         "AWS.#{service_name}"
       :erlang ->

--- a/priv/post.erl.eex
+++ b/priv/post.erl.eex
@@ -33,8 +33,8 @@
 request(Client, Action, Input0, Options) ->
     Client1 = Client#{service => <<"<%= context.signing_name %>">><%= if context.is_global do %>,
                       region => <<"<%= context.credential_scope %>">><% end %>},
-    Host = get_host(<<"<%= context.endpoint_prefix %>">>, Client1),
-    URL = get_url(Host, Client1),
+    Host = build_host(<<"<%= context.endpoint_prefix %>">>, Client1),
+    URL = build_url(Host, Client1),
     Headers = [
         {<<"Host">>, Host},
         {<<"Content-Type">>, <<"<%= context.content_type %>">>}<%= if context.protocol == "json" do %>,
@@ -67,15 +67,15 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
-get_host(_EndpointPrefix, #{region := <<"local">>}) ->
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;<%= if context.is_global do %>
-get_host(EndpointPrefix, #{endpoint := Endpoint}) ->
+build_host(EndpointPrefix, #{endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Endpoint], <<".">>).
 <% else %>
-get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
 <% end %>
-get_url(Host, Client) ->
+build_url(Host, Client) ->
     Proto = maps:get(proto, Client),
     Port = maps:get(port, Client),
     aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>], <<"">>).

--- a/priv/post.ex.eex
+++ b/priv/post.ex.eex
@@ -20,8 +20,8 @@ defmodule <%= context.module_name %> do
   defp request(client, action, input, options) do
     client = %{client | service: "<%= context.signing_name %>"<%= if context.is_global do %>,
                         region:  "<%= context.credential_scope %>"<% end %>}
-    host = get_host("<%= context.endpoint_prefix %>", client)
-    url = get_url(host, client)
+    host = build_host("<%= context.endpoint_prefix %>", client)
+    url = build_url(host, client)
 
     headers = [
       {"Host", host},
@@ -49,18 +49,18 @@ defmodule <%= context.module_name %> do
     end
   end
 
-  defp get_host(_endpoint_prefix, %{region: "local"}) do
+  defp build_host(_endpoint_prefix, %{region: "local"}) do
     "localhost"
   end<%= if context.is_global do %>
-  defp get_host(endpoint_prefix, %{endpoint: endpoint}) do
+  defp build_host(endpoint_prefix, %{endpoint: endpoint}) do
     "#{endpoint_prefix}.#{endpoint}"
   end
 <% else %>
-  defp get_host(endpoint_prefix, %{region: region, endpoint: endpoint}) do
+  defp build_host(endpoint_prefix, %{region: region, endpoint: endpoint}) do
     "#{endpoint_prefix}.#{region}.#{endpoint}"
   end
 <% end %>
-  defp get_url(host, %{:proto => proto, :port => port}) do
+  defp build_url(host, %{:proto => proto, :port => port}) do
     "#{proto}://#{host}:#{port}/"
   end
 end

--- a/priv/rest.erl.eex
+++ b/priv/rest.erl.eex
@@ -118,8 +118,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Client1 = Client#{service => <<"<%= context.signing_name %>">><%= if context.is_global do %>,
                       region => <<"<%= context.credential_scope %>">><% end %>},
     <%= if context.endpoint_prefix == "s3-control" do %>AccountId = proplists:get_value(<<"x-amz-account-id">>, Headers0),
-    Host = get_host(AccountId, <<"<%= context.endpoint_prefix %>">>, Client1),<% else %>Host = get_host(<<"<%= context.endpoint_prefix %>">>, Client1),<% end %>
-    URL0 = get_url(Host, Path, Client1),
+    Host = build_host(AccountId, <<"<%= context.endpoint_prefix %>">>, Client1),<% else %>Host = build_host(<<"<%= context.endpoint_prefix %>">>, Client1),<% end %>
+    URL0 = build_url(Host, Path, Client1),
     URL = aws_request:add_query(URL0, Query),
     AdditionalHeaders = [ {<<"Host">>, Host}
                         , {<<"Content-Type">>, <<"<%= context.content_type %>">>}
@@ -151,22 +151,22 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}, _) ->
 handle_response({error, Reason}, _) ->
   {error, Reason}.
 <%= if context.endpoint_prefix == "s3-control" do %>
-get_host(_AccountId, _EndpointPrefix, #{region := <<"local">>}) ->
+build_host(_AccountId, _EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
-get_host(undefined, _EndpointPrefix, _Client) ->
+build_host(undefined, _EndpointPrefix, _Client) ->
     error(missing_account_id);
-get_host(AccountId, EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+build_host(AccountId, EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([AccountId, EndpointPrefix, Region, Endpoint],
                          <<".">>).<% else %>
-get_host(_EndpointPrefix, #{region := <<"local">>}) ->
+build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;<%= if context.is_global do %>
-get_host(EndpointPrefix, #{endpoint := Endpoint}) ->
+build_host(EndpointPrefix, #{endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Endpoint], <<".">>).
 <% else %>
-get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
 <% end %><% end %>
-get_url(Host, Path0, Client) ->
+build_url(Host, Path0, Client) ->
     Proto = maps:get(proto, Client),
     Path = erlang:iolist_to_binary(Path0),
     Port = maps:get(port, Client),

--- a/priv/rest.erl.eex
+++ b/priv/rest.erl.eex
@@ -30,16 +30,16 @@
 <% else %>
     Headers = [],
 <% end %><%= if length(action.query_parameters) > 0 do %>
-    Query0 =
+    Query0_ =
       [<%= for parameter <- Enum.drop(action.query_parameters, -1) do %>
         {<<"<%= parameter.location_name %>">>, <%= parameter.code_name %>},<% end %><%= for parameter <- Enum.slice action.query_parameters, -1..-1 do %>
         {<<"<%= parameter.location_name %>">>, <%= parameter.code_name %>}
       <% end %>],
-    Query = [H || {_, V} = H <- Query0, V =/= undefined],
+    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
 <% else %>
-    Query = [],
+    Query_ = [],
 <% end %><%= if length(action.response_header_parameters) > 0 do %>
-    case request(Client, get, Path, Query, Headers, undefined, Options, SuccessStatusCode) of
+    case request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode) of
       {ok, Body0, {_, ResponseHeaders, _} = Response} ->
         ResponseHeadersParams =
           [<%= for parameter <- Enum.drop action.response_header_parameters, -1 do %>
@@ -57,7 +57,7 @@
       Result ->
         Result
     end.<% else %>
-    request(Client, get, Path, Query, Headers, undefined, Options, SuccessStatusCode).<% end %>
+    request(Client, get, Path, Query_, Headers, undefined, Options, SuccessStatusCode).<% end %>
 <% else %>
 <%= action.function_name %>(Client<%= AWS.CodeGen.RestService.function_parameters(action) %>, Input) ->
     <%= action.function_name %>(Client<%= AWS.CodeGen.RestService.function_parameters(action) %>, Input, []).
@@ -79,11 +79,11 @@
                      {<<"<%= parameter.location_name %>">>, <<"<%= parameter.name %>">>},<% end %><%= for parameter <- Enum.slice action.query_parameters, -1..-1 do %>
                      {<<"<%= parameter.location_name %>">>, <<"<%= parameter.name %>">>}
                    <% end %>],
-    {Query, Input} = aws_request:build_headers(QueryMapping, Input1),<% else %>
-    Query = [],
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input1),<% else %>
+    Query_ = [],
     Input = Input1,
 <% end %><%= if length(action.response_header_parameters) > 0 do %>
-    case request(Client, Method, Path, Query, Headers, Input, Options, SuccessStatusCode) of
+    case request(Client, Method, Path, Query_, Headers, Input, Options, SuccessStatusCode) of
       {ok, Body0, {_, ResponseHeaders, _} = Response} ->
         ResponseHeadersParams =
           [<%= for parameter <- Enum.drop action.response_header_parameters, -1 do %>
@@ -101,7 +101,7 @@
       Result ->
         Result
     end.<% else %>
-    request(Client, Method, Path, Query, Headers, Input, Options, SuccessStatusCode).<% end %>
+    request(Client, Method, Path, Query_, Headers, Input, Options, SuccessStatusCode).<% end %>
 <% end %><% end %>
 %%====================================================================
 %% Internal functions

--- a/priv/rest.ex.eex
+++ b/priv/rest.ex.eex
@@ -86,9 +86,9 @@ defmodule <%= context.module_name %> do
     client = %{client | service: "<%= context.signing_name %>"<%= if context.is_global do %>,
                         region:  "<%= context.credential_scope %>"<% end %>}
     <%= if context.endpoint_prefix == "s3-control" do %>account_id = :proplists.get_value("x-amz-account-id", headers)
-    host = get_host(account_id, "<%= context.endpoint_prefix %>", client)<% else %>host = get_host("<%= context.endpoint_prefix %>", client)<% end %>
+    host = build_host(account_id, "<%= context.endpoint_prefix %>", client)<% else %>host = build_host("<%= context.endpoint_prefix %>", client)<% end %>
     url = host
-    |> get_url(path, client)
+    |> build_url(path, client)
     |> add_query(query)
 
     additional_headers = [{"Host", host}, {"Content-Type", "<%= context.content_type %>"}]
@@ -134,28 +134,28 @@ defmodule <%= context.module_name %> do
     end
   end
 <%= if context.endpoint_prefix == "s3-control" do %>
-  defp get_host(_account_id, _endpoint_prefix, %{region: "local"}) do
+  defp build_host(_account_id, _endpoint_prefix, %{region: "local"}) do
     "localhost"
   end
-  defp get_host(:undefined, _endpoint_prefix, _client) do
+  defp build_host(:undefined, _endpoint_prefix, _client) do
     raise "missing account_id"
   end
-  defp get_host(account_id, endpoint_prefix, %{region: region, endpoint: endpoint}) do
+  defp build_host(account_id, endpoint_prefix, %{region: region, endpoint: endpoint}) do
     "#{account_id}.#{endpoint_prefix}.#{region}.#{endpoint}"
   end
 <% else %>
-  defp get_host(_endpoint_prefix, %{region: "local"}) do
+  defp build_host(_endpoint_prefix, %{region: "local"}) do
     "localhost"
   end<%= if context.is_global do %>
-  defp get_host(endpoint_prefix, %{endpoint: endpoint}) do
+  defp build_host(endpoint_prefix, %{endpoint: endpoint}) do
     "#{endpoint_prefix}.#{endpoint}"
   end
 <% else %>
-  defp get_host(endpoint_prefix, %{region: region, endpoint: endpoint}) do
+  defp build_host(endpoint_prefix, %{region: region, endpoint: endpoint}) do
     "#{endpoint_prefix}.#{region}.#{endpoint}"
   end
 <% end %><% end %>
-  defp get_url(host, path, %{:proto => proto, :port => port}) do
+  defp build_url(host, path, %{:proto => proto, :port => port}) do
     "#{proto}://#{host}:#{port}#{path}"
   end
 

--- a/priv/rest.ex.eex
+++ b/priv/rest.ex.eex
@@ -17,13 +17,13 @@ defmodule <%= context.module_name %> do
     else
       headers
     end<% end %>
-    query = []<%= for parameter <- Enum.reverse(action.query_parameters) do %>
-    query = if !is_nil(<%= parameter.code_name %>) do
-      [{"<%= parameter.location_name %>", <%= parameter.code_name %>} | query]
+    query_ = []<%= for parameter <- Enum.reverse(action.query_parameters) do %>
+    query_ = if !is_nil(<%= parameter.code_name %>) do
+      [{"<%= parameter.location_name %>", <%= parameter.code_name %>} | query_]
     else
-      query
+      query_
     end<% end %><%= if length(action.response_header_parameters) > 0 do %>
-    case request(client, :get, path_, query, headers, nil, options, <%= inspect(action.success_status_code) %>) do
+    case request(client, :get, path_, query_, headers, nil, options, <%= inspect(action.success_status_code) %>) do
       {:ok, body, response} ->
         body =
           [<%= for parameter <- action.response_header_parameters do %>
@@ -41,7 +41,7 @@ defmodule <%= context.module_name %> do
       result ->
         result
     end<% else %>
-    request(client, :get, path_, query, headers, nil, options, <%= inspect(action.success_status_code) %>)<% end %>
+    request(client, :get, path_, query_, headers, nil, options, <%= inspect(action.success_status_code) %>)<% end %>
   end<% else %>
   def <%= action.function_name %>(client<%= AWS.CodeGen.RestService.function_parameters(action) %>, input, options \\ []) do
     path_ = "<%= AWS.CodeGen.RestService.Action.url_path(action) %>"<%= if length(action.request_header_parameters) > 0 do %>
@@ -51,13 +51,13 @@ defmodule <%= context.module_name %> do
       ]
       |> AWS.Request.build_params(input)<% else %>
     headers = []<% end %><%= if length(action.query_parameters) > 0 do %>
-    {query, input} =
+    {query_, input} =
       [<%= for parameter <- action.query_parameters do %>
         {"<%= parameter.name %>", "<%= parameter.location_name %>"},<% end %>
       ]
       |> AWS.Request.build_params(input)<% else %>
-    query = []<% end %><%= if length(action.response_header_parameters) > 0 do %>
-    case request(client, <%= AWS.CodeGen.RestService.Action.method(action) %>, path_, query, headers, input, options, <%= inspect(action.success_status_code) %>) do
+    query_ = []<% end %><%= if length(action.response_header_parameters) > 0 do %>
+    case request(client, <%= AWS.CodeGen.RestService.Action.method(action) %>, path_, query_, headers, input, options, <%= inspect(action.success_status_code) %>) do
       {:ok, body, response} ->
         body =
           [<%= for parameter <- action.response_header_parameters do %>
@@ -75,7 +75,7 @@ defmodule <%= context.module_name %> do
       result ->
         result
     end<% else %>
-    request(client, <%= AWS.CodeGen.RestService.Action.method(action) %>, path_, query, headers, input, options, <%= inspect(action.success_status_code) %>)<% end %>
+    request(client, <%= AWS.CodeGen.RestService.Action.method(action) %>, path_, query_, headers, input, options, <%= inspect(action.success_status_code) %>)<% end %>
   end<% end %><% end %>
 
   @spec request(AWS.Client.t(), binary(), binary(), list(), list(), map(), list(), pos_integer()) ::


### PR DESCRIPTION
### Description

Replaces the explicit lists of API specifications (for both Erlang and Elixir) with an automatic discovery of the files and availability of implementation for the `{language, protocol}` combination.

Fixes #25.