### PR TITLE
Allow overriding localhost as the endpoint for a local client

### DIFF
--- a/priv/post.erl.eex
+++ b/priv/post.erl.eex
@@ -67,6 +67,8 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
 build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;<%= if context.is_global do %>
 build_host(EndpointPrefix, #{endpoint := Endpoint}) ->

--- a/priv/post.ex.eex
+++ b/priv/post.ex.eex
@@ -49,6 +49,9 @@ defmodule <%= context.module_name %> do
     end
   end
 
+  defp build_host(_endpoint_prefix, %{region: "local", endpoint: endpoint}) do
+    endpoint
+  end
   defp build_host(_endpoint_prefix, %{region: "local"}) do
     "localhost"
   end<%= if context.is_global do %>

--- a/priv/rest.erl.eex
+++ b/priv/rest.erl.eex
@@ -151,6 +151,8 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}, _) ->
 handle_response({error, Reason}, _) ->
   {error, Reason}.
 <%= if context.endpoint_prefix == "s3-control" do %>
+build_host(_AccountId, _EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
 build_host(_AccountId, _EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 build_host(undefined, _EndpointPrefix, _Client) ->
@@ -158,6 +160,8 @@ build_host(undefined, _EndpointPrefix, _Client) ->
 build_host(AccountId, EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([AccountId, EndpointPrefix, Region, Endpoint],
                          <<".">>).<% else %>
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
 build_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;<%= if context.is_global do %>
 build_host(EndpointPrefix, #{endpoint := Endpoint}) ->

--- a/priv/rest.ex.eex
+++ b/priv/rest.ex.eex
@@ -134,6 +134,9 @@ defmodule <%= context.module_name %> do
     end
   end
 <%= if context.endpoint_prefix == "s3-control" do %>
+  defp build_host(_account_id, _endpoint_prefix, %{region: "local", endpoint: endpoint}) do
+    endpoint
+  end
   defp build_host(_account_id, _endpoint_prefix, %{region: "local"}) do
     "localhost"
   end
@@ -144,6 +147,9 @@ defmodule <%= context.module_name %> do
     "#{account_id}.#{endpoint_prefix}.#{region}.#{endpoint}"
   end
 <% else %>
+  defp build_host(_endpoint_prefix, %{region: "local", endpoint: endpoint}) do
+    endpoint
+  end
   defp build_host(_endpoint_prefix, %{region: "local"}) do
     "localhost"
   end<%= if context.is_global do %>


### PR DESCRIPTION
Helps when running DynamoDBLocal in docker, for instance.