### PR TITLE
Add gh actions for erlang/elixir generate testing

### DIFF
--- a/.github/workflows/gen_elixir.yml
+++ b/.github/workflows/gen_elixir.yml
@@ -1,0 +1,44 @@
+name: Generate aws-elixir
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
+    strategy:
+      matrix:
+        include:
+          - elixir: 1.11.x
+            otp: 23.x
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-elixir@v1.4.1
+        with:
+          otp-version: ${{matrix.otp}}
+          elixir-version: ${{matrix.elixir}}
+      - name: Install Dependencies
+        run: |
+          mix local.rebar --force
+          mix local.hex --force
+          mix deps.get
+      - name: Checkout aws/aws-sdk-go
+        uses: actions/checkout@v2
+        with:
+          repository: aws/aws-sdk-go
+          path: aws/aws-sdk-go/
+      - name: Checkout aws-elixir
+        uses: actions/checkout@v2
+        with:
+          repository: aws-beam/aws-elixir
+          path: aws-beam/aws-elixir
+      - name: Generate aws-elixir
+        env:
+          SPEC_PATH: aws/aws-sdk-go/models/apis
+          TEMPLATE_PATH: priv
+          ELIXIR_OUTPUT_PATH: aws-beam/aws-elixir/lib/aws
+        run: mix run generate.exs elixir $SPEC_PATH $TEMPLATE_PATH $ELIXIR_OUTPUT_PATH

--- a/.github/workflows/gen_erlang.yml
+++ b/.github/workflows/gen_erlang.yml
@@ -1,0 +1,44 @@
+name: Generate aws-erlang
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
+    strategy:
+      matrix:
+        include:
+          - elixir: 1.11.x
+            otp: 23.x
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-elixir@v1.4.1
+        with:
+          otp-version: ${{matrix.otp}}
+          elixir-version: ${{matrix.elixir}}
+      - name: Install Dependencies
+        run: |
+          mix local.rebar --force
+          mix local.hex --force
+          mix deps.get
+      - name: Checkout aws/aws-sdk-go
+        uses: actions/checkout@v2
+        with:
+          repository: aws/aws-sdk-go
+          path: aws/aws-sdk-go/
+      - name: Checkout aws-erlang
+        uses: actions/checkout@v2
+        with:
+          repository: aws-beam/aws-erlang
+          path: aws-beam/aws-erlang
+      - name: Generate aws-erlang
+        env:
+          SPEC_PATH: aws/aws-sdk-go/models/apis
+          TEMPLATE_PATH: priv
+          ERLANG_OUTPUT_PATH: aws-beam/aws-erlang/src
+        run: mix run generate.exs erlang $SPEC_PATH $TEMPLATE_PATH $ERLANG_OUTPUT_PATH


### PR DESCRIPTION
Adds two actions to test the generation of the sdk's for both elixir and erlang. It's a basic check, just to see whether the code generation will succeed or return an error code. 

I've split them up in separate actions as other language specific tests may be added later. 

Fixes https://github.com/aws-beam/aws-codegen/issues/42