### PR TITLE
Improve generated Erlang documentation

### DIFF
--- a/lib/aws_codegen/docstring.ex
+++ b/lib/aws_codegen/docstring.ex
@@ -256,9 +256,9 @@ defmodule AWS.CodeGen.Docstring do
         text = Floki.text(children)
 
         if String.contains?(text, "\n") do
-          "\n```\n#{String.trim_leading(text, "\n")}```#{@two_break_lines}"
+          "\n```\n#{String.trim_leading(text, "\n")}'''#{@two_break_lines}"
         else
-          "`#{text}`"
+          "`#{text}'"
         end
 
       {"a", attrs, children} = html_node ->
@@ -273,7 +273,7 @@ defmodule AWS.CodeGen.Docstring do
             end
 
           nil ->
-            "`#{Floki.text(children)}`"
+            "`#{Floki.text(children)}'"
         end
 
       other ->

--- a/lib/aws_codegen/docstring.ex
+++ b/lib/aws_codegen/docstring.ex
@@ -252,6 +252,11 @@ defmodule AWS.CodeGen.Docstring do
       {tag, _, _} = html_node when tag in ~w(p fullname note important div) ->
         update_nodes(html_node)
 
+      {"pre", _, children} ->
+        children
+        |> Floki.text()
+        |> String.replace(~r/(^`|'$)/, "")
+
       {"code", _, children} ->
         text = Floki.text(children)
 

--- a/lib/aws_codegen/rest_service.ex
+++ b/lib/aws_codegen/rest_service.ex
@@ -50,9 +50,9 @@ defmodule AWS.CodeGen.RestService do
             end
           else
             if multi_segment do
-              Enum.join(["\", aws_util:encode_uri(", parameter.code_name,", true), \""])
+              Enum.join(["\", aws_util:encode_multi_segment_uri(", parameter.code_name,"), \""])
             else
-              Enum.join(["\", http_uri:encode(", parameter.code_name, "), \""])
+              Enum.join(["\", aws_util:encode_uri(", parameter.code_name, "), \""])
             end
           end
           # Some url parameters have a trailing "+" indicating they are

--- a/test/aws_codegen/docstring_test.exs
+++ b/test/aws_codegen/docstring_test.exs
@@ -17,7 +17,7 @@ defmodule AWS.CodeGen.DocstringTest do
       text = "<p>Hello,</p> <p><code>world</code></p>!"
       assert "  Hello,\n\n  `world`\n\n  !" == Docstring.format(:elixir, text)
 
-      assert "%% @doc Hello,\n%%\n%% <code>world</code>\n%%\n%% !" ==
+      assert "%% @doc Hello,\n%%\n%% `world`\n%%\n%% !" ==
                Docstring.format(:erlang, text)
     end
 
@@ -164,11 +164,70 @@ defmodule AWS.CodeGen.DocstringTest do
 
       assert expected == Docstring.format(:elixir, text)
     end
-  end
 
-  test "html_to_edoc/1 renders <fullname> tags as distinct paragraphs" do
-    text = "<fullname>Hello, world!</fullname>"
-    assert "<fullname>Hello, world!</fullname>\n\n" == Docstring.html_to_edoc(text)
+    test "removes some tags and add spacing after them" do
+      text = """
+      <p>A short description</p>
+
+      <div>This is a div</div>
+      <fullname>Fullname node</fullname>
+      <note>Here is a note</note>
+      <div class="seeAlso">See also div</div>
+      """
+
+      expected =
+        String.trim(
+          """
+          %% @doc A short description
+          %%
+          %% This is a div
+          %%
+          %% Fullname node
+          %%
+          %% Here is a note
+          %%
+          %% See also: See also div
+          """,
+          "\n"
+        )
+
+      assert expected == Docstring.format(:erlang, text)
+    end
+
+    test "formats a, code and p (as title) tags" do
+      text = """
+      A short description. This is a <a href="https://foo.bar">link</a>.
+      This is a <code>code</code> and a multiline is here:
+      <code>
+      puts "hello"
+      </code>
+      <p class="title">Section title</p>
+      Here is a link with the same text: <a href="https://foo">https://foo</a>
+      And a link without href: <a>without href</a>
+      """
+
+      expected =
+        String.trim(
+          """
+          %% @doc A short description.
+          %%
+          %% This is a <a href="https://foo.bar">link</a>.
+          %% This is a `code` and a multiline is here:
+          %%
+          %% ```
+          %% puts "hello"
+          %% ```
+          %%
+          %% == Section title ==
+          %%
+          %% Here is a link with the same text: [https://foo]
+          %% And a link without href: `without href`
+          """,
+          "\n"
+        )
+
+      assert expected == Docstring.format(:erlang, text)
+    end
   end
 
   test "html_to_markdown/1 replaces <code> tags with backticks" do

--- a/test/aws_codegen/docstring_test.exs
+++ b/test/aws_codegen/docstring_test.exs
@@ -17,7 +17,7 @@ defmodule AWS.CodeGen.DocstringTest do
       text = "<p>Hello,</p> <p><code>world</code></p>!"
       assert "  Hello,\n\n  `world`\n\n  !" == Docstring.format(:elixir, text)
 
-      assert "%% @doc Hello,\n%%\n%% `world`\n%%\n%% !" ==
+      assert "%% @doc Hello,\n%%\n%% `world'\n%%\n%% !" ==
                Docstring.format(:erlang, text)
     end
 
@@ -212,16 +212,16 @@ defmodule AWS.CodeGen.DocstringTest do
           %% @doc A short description.
           %%
           %% This is a <a href="https://foo.bar">link</a>.
-          %% This is a `code` and a multiline is here:
+          %% This is a `code' and a multiline is here:
           %%
           %% ```
           %% puts "hello"
-          %% ```
+          %% '''
           %%
           %% == Section title ==
           %%
           %% Here is a link with the same text: [https://foo]
-          %% And a link without href: `without href`
+          %% And a link without href: `without href'
           """,
           "\n"
         )


### PR DESCRIPTION
This PR makes the generated EDoc documentation (Erlang) more easier
to read and more concise, according to rules from the [Wiki notation](http://erlang.org/doc/apps/edoc/chapter.html#wiki-notation).

## Demo

:point_right: https://tmp-aws-docs-erlang-dxsraxvsv.vercel.app/
The generated code is in the following PR: https://github.com/aws-beam/aws-erlang/pull/37