### PR TITLE
Improve build workflows by using Hex.pm images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,19 +8,24 @@ on:
       - master
 jobs:
   build:
-    strategy:
-      matrix:
-        platform: [ubuntu-latest]
-        elixir: ['1.8.2', '1.9.4', '1.10.4', '1.11.1']
-    runs-on: ${{ matrix.platform }}
+    runs-on: ubuntu-latest
     container:
-      image: elixir:${{ matrix.elixir }}-slim
+      image: hexpm/elixir:${{ matrix.elixir }}-erlang-${{ matrix.erlang }}-ubuntu-${{ matrix.ubuntu }}
+
+    name: Elixir ${{ matrix.elixir }} / Erlang ${{ matrix.erlang }} with Ubuntu ${{matrix.ubuntu}}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        elixir: ["1.11.2"]
+        erlang: ["23.1.4"]
+        ubuntu: ["focal-20201008"]
     steps:
       - uses: actions/checkout@v2
       - name: Install Dependencies
         run: |
           apt-get update
-          apt-get -y install build-essential cmake
+          DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install build-essential cmake
           mix local.rebar --force
           mix local.hex --force
           mix deps.get

--- a/.github/workflows/gen_elixir.yml
+++ b/.github/workflows/gen_elixir.yml
@@ -9,22 +9,23 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
+    container:
+      image: hexpm/elixir:${{ matrix.elixir }}-erlang-${{ matrix.erlang }}-ubuntu-${{ matrix.ubuntu }}
+
+    name: Elixir ${{ matrix.elixir }} / Erlang ${{ matrix.erlang }} with Ubuntu ${{matrix.ubuntu}}
+
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - elixir: 1.11.x
-            otp: 23.x
+        elixir: ["1.11.2"]
+        erlang: ["23.1.4"]
+        ubuntu: ["focal-20201008"]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-elixir@v1.4.1
-        with:
-          otp-version: ${{matrix.otp}}
-          elixir-version: ${{matrix.elixir}}
       - name: Install Dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get -y install build-essential cmake
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install build-essential cmake
           mix local.rebar --force
           mix local.hex --force
           mix deps.get

--- a/.github/workflows/gen_erlang.yml
+++ b/.github/workflows/gen_erlang.yml
@@ -9,22 +9,23 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
+    container:
+      image: hexpm/elixir:${{ matrix.elixir }}-erlang-${{ matrix.erlang }}-ubuntu-${{ matrix.ubuntu }}
+
+    name: Elixir ${{ matrix.elixir }} / Erlang ${{ matrix.erlang }} with Ubuntu ${{matrix.ubuntu}}
+
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - elixir: 1.11.x
-            otp: 23.x
+        elixir: ["1.11.2"]
+        erlang: ["23.1.4"]
+        ubuntu: ["focal-20201008"]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-elixir@v1.4.1
-        with:
-          otp-version: ${{matrix.otp}}
-          elixir-version: ${{matrix.elixir}}
       - name: Install Dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get -y install build-essential cmake
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install build-essential cmake
           mix local.rebar --force
           mix local.hex --force
           mix deps.get

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: elixir
-elixir: 1.4.2
-otp_release: 19.1


### PR DESCRIPTION
It uses the same images for all workflows.
It only runs against the latest Elixir, because this project won't have dependents.

PS: My next PR is only compatible with Elixir 1.11, so this is why I'm doing this change.