### PR TITLE
Remove "request code" from Elixir templates

### DIFF
--- a/lib/aws_codegen.ex
+++ b/lib/aws_codegen.ex
@@ -15,6 +15,28 @@ defmodule AWS.CodeGen do
   if there is an available implementation for that protocol.
   """
 
+  defmodule Service do
+    @moduledoc false
+
+    defstruct abbreviation: nil,
+              actions: [],
+              api_version: nil,
+              credential_scope: nil,
+              content_type: nil,
+              docstring: nil,
+              decode: nil,
+              encode: nil,
+              endpoint_prefix: nil,
+              is_global: false,
+              json_version: nil,
+              module_name: nil,
+              protocol: nil,
+              signature_version: nil,
+              service_id: nil,
+              signing_name: nil,
+              target_prefix: nil
+  end
+
   # Configuration map which determines what AWS API protocols have an
   # implementation for what language.
   @configuration %{

--- a/lib/aws_codegen.ex
+++ b/lib/aws_codegen.ex
@@ -1,5 +1,6 @@
 defmodule AWS.CodeGen do
   alias AWS.CodeGen.Spec
+
   @moduledoc """
   AWS API Services generator.
 
@@ -17,32 +18,32 @@ defmodule AWS.CodeGen do
   # Configuration map which determines what AWS API protocols have an
   # implementation for what language.
   @configuration %{
-    :json => %{
-      :module => AWS.CodeGen.PostService,
-      :template => %{
-        :elixir => "post.ex.eex",
-        :erlang => "post.erl.eex"
+    json: %{
+      module: AWS.CodeGen.PostService,
+      template: %{
+        elixir: "post.ex.eex",
+        erlang: "post.erl.eex"
       }
     },
-    :rest_json => %{
-      :module => AWS.CodeGen.RestService,
-      :template => %{
-        :elixir => "rest.ex.eex",
-        :erlang => "rest.erl.eex"
+    rest_json: %{
+      module: AWS.CodeGen.RestService,
+      template: %{
+        elixir: "rest.ex.eex",
+        erlang: "rest.erl.eex"
       }
     },
-    :query => %{
-      :module => AWS.CodeGen.PostService,
-      :template => %{
-        :elixir => "post.ex.eex",
-        :erlang => "post.erl.eex"
+    query: %{
+      module: AWS.CodeGen.PostService,
+      template: %{
+        elixir: "post.ex.eex",
+        erlang: "post.erl.eex"
       }
     },
-    :rest_xml => %{
-      :module => AWS.CodeGen.RestService,
-      :template => %{
-        :elixir => "rest.ex.eex",
-        :erlang => "rest.erl.eex"
+    rest_xml: %{
+      module: AWS.CodeGen.RestService,
+      template: %{
+        elixir: "rest.ex.eex",
+        erlang: "rest.erl.eex"
       }
     }
   }
@@ -52,13 +53,18 @@ defmodule AWS.CodeGen do
   """
   def generate(language, spec_base_path, template_base_path, output_base_path) do
     endpoints_spec = get_endpoints_spec(spec_base_path)
-    tasks = Enum.map(api_specs(spec_base_path, language),
-      fn(spec) ->
-        output_path = Path.join(output_base_path, spec.filename)
-        args = [spec, language, endpoints_spec, template_base_path, output_path]
-        Task.async(AWS.CodeGen, :generate_code, args)
-      end)
-    Enum.each(tasks, fn(task) -> Task.await(task) end)
+
+    tasks =
+      Enum.map(
+        api_specs(spec_base_path, language),
+        fn spec ->
+          output_path = Path.join(output_base_path, spec.filename)
+          args = [spec, language, endpoints_spec, template_base_path, output_path]
+          Task.async(AWS.CodeGen, :generate_code, args)
+        end
+      )
+
+    Enum.each(tasks, fn task -> Task.await(task) end)
   end
 
   @doc """
@@ -68,7 +74,8 @@ defmodule AWS.CodeGen do
   """
   def generate_code(spec, language, endpoints_spec, template_base_path, output_path) do
     template = @configuration[spec.protocol][:template][language]
-    if not is_nil(template) do
+
+    if template do
       protocol_service = @configuration[spec.protocol][:module]
       template_path = Path.join(template_base_path, template)
       args = [language, spec.module_name, endpoints_spec, spec.api, spec.doc]
@@ -77,13 +84,14 @@ defmodule AWS.CodeGen do
       IO.puts(["Writing ", spec.module_name, " to ", output_path])
       File.write(output_path, code)
     else
-      IO.puts("Failed to generate #{spec.module_name}, protocol #{Atom.to_string(spec.protocol)}")
+      IO.puts("Failed to generate #{spec.module_name}, protocol #{spec.protocol}")
     end
   end
 
   defp api_specs(base_path, language) do
     search_path = Path.join(base_path, "*/*")
     IO.puts("Parsing specs in #{search_path}")
+
     for path <- Path.wildcard(search_path) do
       Spec.parse(path, language)
     end
@@ -91,10 +99,9 @@ defmodule AWS.CodeGen do
 
   defp get_endpoints_spec(base_path) do
     Path.join([base_path, "..", "endpoints", "endpoints.json"])
-    |> Spec.parse_json
+    |> Spec.parse_json()
     |> get_in(["partitions"])
-    |> Enum.filter(fn(x) -> x["partition"] == "aws" end)
-    |> List.first
+    |> Enum.filter(fn x -> x["partition"] == "aws" end)
+    |> List.first()
   end
-
 end

--- a/lib/aws_codegen/name.ex
+++ b/lib/aws_codegen/name.ex
@@ -1,14 +1,12 @@
 defmodule AWS.CodeGen.Name do
+  @names_to_capitalize ~w(iSCSI BGP CSV NFS VTL UUID)
+
   @doc """
   Convert `CamelCase` or `nerdyCaps` to `snake_case`.
   """
   def to_snake_case(text) do
-    String.replace(text, "iSCSI", "Iscsi")
-    |> String.replace("BGP", "Bgp")
-    |> String.replace("CSV", "Csv")
-    |> String.replace("NFS", "Nfs")
-    |> String.replace("VTL", "Vtl")
-    |> String.replace("UUID", "Uuid")
+    text
+    |> String.replace(@names_to_capitalize, &String.capitalize(&1))
     |> String.to_charlist()
     |> Enum.map_join(&char_to_snake_case/1)
     |> String.trim_leading("_")
@@ -17,11 +15,11 @@ defmodule AWS.CodeGen.Name do
   defp char_to_snake_case(char) do
     char = List.to_string([char])
     lower_char = String.downcase(char)
-    case lower_char == char do
-      true ->
-        lower_char
-      false ->
-        "_#{lower_char}"
+
+    if lower_char == char do
+      lower_char
+    else
+      "_#{lower_char}"
     end
   end
 

--- a/lib/aws_codegen/post_service.ex
+++ b/lib/aws_codegen/post_service.ex
@@ -15,6 +15,8 @@ defmodule AWS.CodeGen.PostService do
               json_version: nil,
               module_name: nil,
               protocol: nil,
+              signature_version: nil,
+              service_id: nil,
               signing_name: nil,
               target_prefix: nil
   end
@@ -94,6 +96,8 @@ defmodule AWS.CodeGen.PostService do
       module_name: module_name,
       protocol: protocol,
       signing_name: signing_name,
+      signature_version: api_spec["metadata"]["signatureVersion"],
+      service_id: api_spec["metadata"]["serviceId"],
       target_prefix: api_spec["metadata"]["targetPrefix"]
     }
   end

--- a/lib/aws_codegen/post_service.ex
+++ b/lib/aws_codegen/post_service.ex
@@ -1,25 +1,6 @@
 defmodule AWS.CodeGen.PostService do
   alias AWS.CodeGen.Docstring
-
-  defmodule Service do
-    defstruct abbreviation: nil,
-              actions: [],
-              api_version: nil,
-              credential_scope: nil,
-              content_type: nil,
-              docstring: nil,
-              decode: nil,
-              encode: nil,
-              endpoint_prefix: nil,
-              is_global: false,
-              json_version: nil,
-              module_name: nil,
-              protocol: nil,
-              signature_version: nil,
-              service_id: nil,
-              signing_name: nil,
-              target_prefix: nil
-  end
+  alias AWS.CodeGen.Service
 
   defmodule Action do
     defstruct arity: nil,

--- a/lib/aws_codegen/rest_service.ex
+++ b/lib/aws_codegen/rest_service.ex
@@ -3,6 +3,7 @@ defmodule AWS.CodeGen.RestService do
 
   defmodule Service do
     defstruct abbreviation: nil,
+              api_version: nil,
               actions: [],
               credential_scope: nil,
               content_type: nil,
@@ -15,6 +16,8 @@ defmodule AWS.CodeGen.RestService do
               module_name: nil,
               protocol: nil,
               signing_name: nil,
+              signature_version: nil,
+              service_id: nil,
               target_prefix: nil
   end
 
@@ -125,6 +128,7 @@ defmodule AWS.CodeGen.RestService do
 
     %Service{
       actions: actions,
+      api_version: api_spec["metadata"]["apiVersion"],
       docstring: Docstring.format(language, doc_spec["service"]),
       credential_scope: credential_scope,
       content_type: @configuration[protocol][:content_type],
@@ -136,6 +140,8 @@ defmodule AWS.CodeGen.RestService do
       module_name: module_name,
       protocol: api_spec["metadata"]["protocol"],
       signing_name: signing_name,
+      signature_version: api_spec["metadata"]["signatureVersion"],
+      service_id: api_spec["metadata"]["serviceId"],
       target_prefix: api_spec["metadata"]["targetPrefix"]
     }
   end

--- a/lib/aws_codegen/rest_service.ex
+++ b/lib/aws_codegen/rest_service.ex
@@ -1,25 +1,6 @@
 defmodule AWS.CodeGen.RestService do
   alias AWS.CodeGen.Docstring
-
-  defmodule Service do
-    defstruct abbreviation: nil,
-              api_version: nil,
-              actions: [],
-              credential_scope: nil,
-              content_type: nil,
-              docstring: nil,
-              decode: nil,
-              encode: nil,
-              endpoint_prefix: nil,
-              is_global: false,
-              json_version: nil,
-              module_name: nil,
-              protocol: nil,
-              signing_name: nil,
-              signature_version: nil,
-              service_id: nil,
-              target_prefix: nil
-  end
+  alias AWS.CodeGen.Service
 
   defmodule Action do
     alias AWS.CodeGen.RestService.Parameter

--- a/lib/aws_codegen/spec.ex
+++ b/lib/aws_codegen/spec.ex
@@ -3,7 +3,7 @@ defmodule AWS.CodeGen.Spec do
   Parse and process the specfication for an AWS service.
   """
 
-  @module_acronyms ~w(SMS WAF API SES HSM FSx IoT MTurk QLDB DB RDS A2I XRay)
+  @module_acronyms ~w(SMS WAF API SES HSM FSx IoT MTurk QLDB DB RDS A2I XRay EC2)
 
   defstruct protocol: nil,
             module_name: nil,

--- a/lib/aws_codegen/spec.ex
+++ b/lib/aws_codegen/spec.ex
@@ -2,19 +2,26 @@ defmodule AWS.CodeGen.Spec do
   @moduledoc """
   Parse and process the specfication for an AWS service.
   """
+
+  @module_acronyms ~w(SMS WAF API SES HSM FSx IoT MTurk QLDB DB RDS A2I XRay)
+
   defstruct protocol: nil,
-    module_name: nil,
-    filename: nil,
-    api: nil,
-    doc: nil
+            module_name: nil,
+            filename: nil,
+            api: nil,
+            doc: nil
 
   def parse(path, language) do
     api = path |> Path.join("api-2.json") |> parse_json
-    protocol = api["metadata"]["protocol"]
-    |> String.replace("-", "_")
-    |> String.to_atom
+
+    protocol =
+      api["metadata"]["protocol"]
+      |> String.replace("-", "_")
+      |> String.to_atom()
+
     module_name = module_name(api, language)
     filename = filename(module_name, language)
+
     %AWS.CodeGen.Spec{
       protocol: protocol,
       module_name: module_name,
@@ -26,65 +33,59 @@ defmodule AWS.CodeGen.Spec do
 
   def parse_json(path) do
     if File.exists?(path) do
-      path |> File.read! |> Poison.Parser.parse!(%{})
+      path |> File.read!() |> Poison.Parser.parse!(%{})
     end
   end
 
   defp module_name(api, language) do
-    service_name = case api["metadata"]["serviceId"] do
-                     nil -> api["metadata"]["endpointPrefix"]
-                     service_id -> service_id
-                   end
-    |> String.replace("-sync", "Sync")
-    |> String.replace("Route 53", "Route53")
-    |> String.replace(~r/ Service$/, "")
-    |> String.replace("dynamodb", "DynamoDB")
-    |> String.replace("api.pricing", "API.Pricing")
-    |> String.replace("entitlement.marketplace", "Entitlement.Marketplace")
+    service_name =
+      (api["metadata"]["serviceId"] || api["metadata"]["endpointPrefix"])
+      |> String.replace("-sync", "Sync")
+      |> String.replace("Route 53", "Route53")
+      |> String.replace(~r/ Service$/, "")
+      |> String.replace("dynamodb", "DynamoDB")
+      |> String.replace("api.pricing", "API.Pricing")
+      |> String.replace("entitlement.marketplace", "Entitlement.Marketplace")
+
     case language do
       :elixir ->
-        service_name = service_name
-        |> String.replace(" connections", " Connections")
-        |> String.replace(" ", "")
-        |> AWS.CodeGen.Name.upcase_first
+        service_name =
+          service_name
+          |> String.replace(" connections", " Connections")
+          |> String.replace(" ", "")
+          |> AWS.CodeGen.Name.upcase_first()
+
         "AWS.#{service_name}"
+
       :erlang ->
-        service_name = service_name
-        |> String.replace(" ", "_")
-        |> String.replace(".", "_")
-        |> String.downcase
-        |> AWS.CodeGen.Name.to_snake_case
+        service_name =
+          service_name
+          |> String.replace(" ", "_")
+          |> String.replace(".", "_")
+          |> String.downcase()
+          |> AWS.CodeGen.Name.to_snake_case()
+
         "aws_#{service_name}"
     end
   end
 
   defp filename(module_name, :elixir) do
-    module_name = module_name
-    |> String.replace("AWS.", "")
-    |> String.replace("SMS", "Sms")
-    |> String.replace("WAF", "Waf")
-    |> String.replace("API", "Api")
-    |> String.replace("SES", "Ses")
-    |> String.replace("HSM", "Hsm")
-    |> String.replace("EC2", "Ec2")
-    |> String.replace("DynamoDB", "Dynamodb")
-    |> String.replace("ElastiCache", "Elasticache")
-    |> String.replace("FSx", "Fsx")
-    |> String.replace("IoT", "Iot")
-    |> String.replace("MTurk", "Mturk")
-    |> String.replace("QLDB", "Qldb")
-    |> String.replace("DB", "Db")
-    |> String.replace("RDS", "Rds")
-    |> String.replace("A2I", "A2i")
-    |> String.replace("XRay", "Xray")
-    |> String.replace(".", "")
-    name = if module_name == String.upcase(module_name) do
-      String.downcase(module_name)
-    else
-      AWS.CodeGen.Name.to_snake_case(module_name)
-    end
+    module_name =
+      module_name
+      |> String.replace("AWS.", "")
+      |> String.replace(@module_acronyms ++ ~w(DynamoDB ElastiCache), &String.capitalize(&1))
+      |> String.replace(".", "")
+
+    name =
+      if module_name == String.upcase(module_name) do
+        String.downcase(module_name)
+      else
+        AWS.CodeGen.Name.to_snake_case(module_name)
+      end
+
     "#{name}.ex"
   end
+
   defp filename(module_name, :erlang) do
     "#{module_name}.erl"
   end

--- a/priv/post.ex.eex
+++ b/priv/post.ex.eex
@@ -6,6 +6,9 @@ defmodule <%= context.module_name %> do
 <%= context.docstring %>
   """
 
+  alias AWS.Client
+  alias AWS.Request
+
   def metadata do
     %AWS.ServiceMetadata{
       abbreviation: <%= inspect(context.abbreviation) %>,
@@ -25,67 +28,8 @@ defmodule <%= context.module_name %> do
   @doc """
 <%= action.docstring %>
   """
-  def <%= action.function_name %>(client, input, options \\ []) do
-    request(client, "<%= action.name %>", input, options)
+  def <%= action.function_name %>(%Client{} = client, input, options \\ []) do
+    Request.request_post(client, metadata(), "<%= action.name %>", input, options)
   end
 <% end %>
-  @spec request(AWS.Client.t(), binary(), map(), list()) ::
-          {:ok, map() | nil, map()}
-          | {:error, term()}
-  defp request(client, action, input, options) do
-    client = %{client | service: "<%= context.signing_name %>"<%= if context.is_global do %>,
-                        region:  "<%= context.credential_scope %>"<% end %>}
-    host = build_host("<%= context.endpoint_prefix %>", client)
-    url = build_url(host, client)
-
-    headers = [
-      {"Host", host},
-      {"Content-Type", "<%= context.content_type %>"}<%= if context.protocol == "json" do %>,
-      {"X-Amz-Target", "<%= context.target_prefix %>.#{action}"}<% end %>
-    ]
-<%= if context.protocol == "query" do %>
-    input = Map.merge(input, %{"Action" => action, "Version" => "<%= context.api_version %>"})<% end %>
-    payload = encode!(client, input)
-    headers = AWS.Request.sign_v4(client, "POST", url, headers, payload)
-    post(client, url, payload, headers, options)
-  end
-
-  defp post(client, url, payload, headers, options) do
-    case AWS.Client.request(client, :post, url, payload, headers, options) do
-      {:ok, %{status_code: 200, body: body} = response} ->
-        body = if body != "", do: decode!(client, body)
-        {:ok, body, response}
-
-      {:ok, response} ->
-        {:error, {:unexpected_response, response}}
-
-      error = {:error, _reason} -> error
-    end
-  end
-
-  defp build_host(_endpoint_prefix, %{region: "local", endpoint: endpoint}) do
-    endpoint
-  end
-  defp build_host(_endpoint_prefix, %{region: "local"}) do
-    "localhost"
-  end<%= if context.is_global do %>
-  defp build_host(endpoint_prefix, %{endpoint: endpoint}) do
-    "#{endpoint_prefix}.#{endpoint}"
-  end
-<% else %>
-  defp build_host(endpoint_prefix, %{region: region, endpoint: endpoint}) do
-    "#{endpoint_prefix}.#{region}.#{endpoint}"
-  end
-<% end %>
-  defp build_url(host, %{:proto => proto, :port => port}) do
-    "#{proto}://#{host}:#{port}/"
-  end
-
-  defp encode!(client, payload) do
-    AWS.Client.encode!(client, payload, :<%= context.encode %>)
-  end
-
-  defp decode!(client, payload) do
-    AWS.Client.decode!(client, payload, :<%= context.decode %>)
-  end
 end

--- a/priv/post.ex.eex
+++ b/priv/post.ex.eex
@@ -5,6 +5,22 @@ defmodule <%= context.module_name %> do
   @moduledoc """
 <%= context.docstring %>
   """
+
+  def metadata do
+    %AWS.ServiceMetadata{
+      abbreviation: <%= inspect(context.abbreviation) %>,
+      api_version: <%= inspect(context.api_version) %>,
+      content_type: <%= inspect(context.content_type) %>,
+      credential_scope: <%= inspect(context.credential_scope) %>,
+      endpoint_prefix: <%= inspect(context.endpoint_prefix) %>,
+      global?: <%= inspect(context.is_global) %>,
+      protocol: <%= inspect(context.protocol) %>,
+      service_id: <%= inspect(context.service_id) %>,
+      signature_version: <%= inspect(context.signature_version) %>,
+      signing_name: <%= inspect(context.signing_name) %>,
+      target_prefix: <%= inspect(context.target_prefix) %>
+    }
+  end
 <%= for action <- context.actions do %>
   @doc """
 <%= action.docstring %>

--- a/priv/rest.ex.eex
+++ b/priv/rest.ex.eex
@@ -4,7 +4,23 @@
 defmodule <%= context.module_name %> do
   @moduledoc """
 <%= context.docstring %>
-  """<%= for action <- context.actions do %>
+  """
+
+  def metadata do
+    %AWS.ServiceMetadata{
+      abbreviation: <%= inspect(context.abbreviation) %>,
+      api_version: <%= inspect(context.api_version) %>,
+      content_type: <%= inspect(context.content_type) %>,
+      credential_scope: <%= inspect(context.credential_scope) %>,
+      endpoint_prefix: <%= inspect(context.endpoint_prefix) %>,
+      global?: <%= inspect(context.is_global) %>,
+      protocol: <%= inspect(context.protocol) %>,
+      service_id: <%= inspect(context.service_id) %>,
+      signature_version: <%= inspect(context.signature_version) %>,
+      signing_name: <%= inspect(context.signing_name) %>,
+      target_prefix: <%= inspect(context.target_prefix) %>
+    }
+  end<%= for action <- context.actions do %>
 
   @doc """
 <%= action.docstring %>

--- a/priv/rest.ex.eex
+++ b/priv/rest.ex.eex
@@ -6,6 +6,9 @@ defmodule <%= context.module_name %> do
 <%= context.docstring %>
   """
 
+  alias AWS.Client
+  alias AWS.Request
+
   def metadata do
     %AWS.ServiceMetadata{
       abbreviation: <%= inspect(context.abbreviation) %>,
@@ -25,155 +28,45 @@ defmodule <%= context.module_name %> do
   @doc """
 <%= action.docstring %>
   """<%= if action.method == "GET" do %>
-  def <%= action.function_name %>(client<%= AWS.CodeGen.RestService.function_parameters(action) %>, options \\ []) do
-    path_ = "<%= AWS.CodeGen.RestService.Action.url_path(action) %>"
+  def <%= action.function_name %>(%Client{} = client<%= AWS.CodeGen.RestService.function_parameters(action) %>, options \\ []) do
+    url_path = "<%= AWS.CodeGen.RestService.Action.url_path(action) %>"
     headers = []<%= for parameter <- action.request_header_parameters do %>
     headers = if !is_nil(<%= parameter.code_name %>) do
       [{"<%= parameter.location_name %>", <%= parameter.code_name %>} | headers]
     else
       headers
     end<% end %>
-    query_ = []<%= for parameter <- Enum.reverse(action.query_parameters) do %>
-    query_ = if !is_nil(<%= parameter.code_name %>) do
-      [{"<%= parameter.location_name %>", <%= parameter.code_name %>} | query_]
+    query_params = []<%= for parameter <- Enum.reverse(action.query_parameters) do %>
+    query_params = if !is_nil(<%= parameter.code_name %>) do
+      [{"<%= parameter.location_name %>", <%= parameter.code_name %>} | query_params]
     else
-      query_
+      query_params
     end<% end %><%= if length(action.response_header_parameters) > 0 do %>
-    case request(client, :get, path_, query_, headers, nil, options, <%= inspect(action.success_status_code) %>) do
-      {:ok, body, response} when not is_nil(body) ->
-        body =
-          [<%= for parameter <- action.response_header_parameters do %>
-            {"<%= parameter.location_name %>", "<%= parameter.name %>"},<% end %>
-          ]
-          |> Enum.reduce(body, fn {header_name, key}, acc ->
-            case List.keyfind(response.headers, header_name, 0) do
-              nil -> acc
-              {_header_name, value} -> Map.put(acc, key, value)
-            end
-          end)
-
-        {:ok, body, response}
-
-      result ->
-        result
-    end<% else %>
-    request(client, :get, path_, query_, headers, nil, options, <%= inspect(action.success_status_code) %>)<% end %>
-  end<% else %>
-  def <%= action.function_name %>(client<%= AWS.CodeGen.RestService.function_parameters(action) %>, input, options \\ []) do
-    path_ = "<%= AWS.CodeGen.RestService.Action.url_path(action) %>"<%= if length(action.request_header_parameters) > 0 do %>
+    options = Keyword.put(
+      options,
+      :response_header_parameters,
+      <%= inspect((for param <- action.response_header_parameters, do: {param.location_name, param.name}), pretty: true) %>
+    )<% end %>
+    Request.request_rest(client, metadata(), :get, url_path, query_params, headers, nil, options, <%= inspect(action.success_status_code) %>)<% else %>
+  def <%= action.function_name %>(%Client{} = client<%= AWS.CodeGen.RestService.function_parameters(action) %>, input, options \\ []) do
+    url_path = "<%= AWS.CodeGen.RestService.Action.url_path(action) %>"<%= if length(action.request_header_parameters) > 0 do %>
     {headers, input} =
       [<%= for parameter <- action.request_header_parameters do %>
         {"<%= parameter.name %>", "<%= parameter.location_name %>"},<% end %>
       ]
-      |> AWS.Request.build_params(input)<% else %>
+      |> Request.build_params(input)<% else %>
     headers = []<% end %><%= if length(action.query_parameters) > 0 do %>
-    {query_, input} =
+    {query_params, input} =
       [<%= for parameter <- action.query_parameters do %>
         {"<%= parameter.name %>", "<%= parameter.location_name %>"},<% end %>
       ]
-      |> AWS.Request.build_params(input)<% else %>
-    query_ = []<% end %><%= if length(action.response_header_parameters) > 0 do %>
-    case request(client, <%= AWS.CodeGen.RestService.Action.method(action) %>, path_, query_, headers, input, options, <%= inspect(action.success_status_code) %>) do
-      {:ok, body, response} when not is_nil(body) ->
-        body =
-          [<%= for parameter <- action.response_header_parameters do %>
-            {"<%= parameter.location_name %>", "<%= parameter.name %>"},<% end %>
-          ]
-          |> Enum.reduce(body, fn {header_name, key}, acc ->
-            case List.keyfind(response.headers, header_name, 0) do
-              nil -> acc
-              {_header_name, value} -> Map.put(acc, key, value)
-            end
-          end)
-
-        {:ok, body, response}
-
-      result ->
-        result
-    end<% else %>
-    request(client, <%= AWS.CodeGen.RestService.Action.method(action) %>, path_, query_, headers, input, options, <%= inspect(action.success_status_code) %>)<% end %>
-  end<% end %><% end %>
-
-  @spec request(AWS.Client.t(), binary(), binary(), list(), list(), map(), list(), pos_integer()) ::
-          {:ok, map() | nil, map()}
-          | {:error, term()}
-  defp request(client, method, path, query, headers, input, options, success_status_code) do
-    client = %{client | service: "<%= context.signing_name %>"<%= if context.is_global do %>,
-                        region:  "<%= context.credential_scope %>"<% end %>}
-    <%= if context.endpoint_prefix == "s3-control" do %>account_id = :proplists.get_value("x-amz-account-id", headers)
-    host = build_host(account_id, "<%= context.endpoint_prefix %>", client)<% else %>host = build_host("<%= context.endpoint_prefix %>", client)<% end %>
-    url = host
-    |> build_url(path, client)
-    |> add_query(query, client)
-
-    additional_headers = [{"Host", host}, {"Content-Type", "<%= context.content_type %>"}]
-    headers = AWS.Request.add_headers(additional_headers, headers)
-
-    payload = encode!(client, input)
-    headers = AWS.Request.sign_v4(client, method, url, headers, payload)
-    perform_request(client, method, url, payload, headers, options, success_status_code)
-  end
-
-  defp perform_request(client, method, url, payload, headers, options, success_status_code) do
-    case AWS.Client.request(client, method, url, payload, headers, options) do
-      {:ok, %{status_code: status_code, body: body} = response}
-      when is_nil(success_status_code) and status_code in [200, 202, 204]
-      when status_code == success_status_code ->
-        body = if(body != "", do: decode!(client, body))
-        {:ok, body, response}
-
-      {:ok, response} ->
-        {:error, {:unexpected_response, response}}
-
-      error = {:error, _reason} -> error
-    end
-  end
-
-<%= if context.endpoint_prefix == "s3-control" do %>
-  defp build_host(_account_id, _endpoint_prefix, %{region: "local", endpoint: endpoint}) do
-    endpoint
-  end
-  defp build_host(_account_id, _endpoint_prefix, %{region: "local"}) do
-    "localhost"
-  end
-  defp build_host(:undefined, _endpoint_prefix, _client) do
-    raise "missing account_id"
-  end
-  defp build_host(account_id, endpoint_prefix, %{region: region, endpoint: endpoint}) do
-    "#{account_id}.#{endpoint_prefix}.#{region}.#{endpoint}"
-  end
-<% else %>
-  defp build_host(_endpoint_prefix, %{region: "local", endpoint: endpoint}) do
-    endpoint
-  end
-  defp build_host(_endpoint_prefix, %{region: "local"}) do
-    "localhost"
-  end<%= if context.is_global do %>
-  defp build_host(endpoint_prefix, %{endpoint: endpoint}) do
-    "#{endpoint_prefix}.#{endpoint}"
-  end
-<% else %>
-  defp build_host(endpoint_prefix, %{region: region, endpoint: endpoint}) do
-    "#{endpoint_prefix}.#{region}.#{endpoint}"
-  end
-<% end %><% end %>
-  defp build_url(host, path, %{:proto => proto, :port => port}) do
-    "#{proto}://#{host}:#{port}#{path}"
-  end
-
-  defp add_query(url, [], _client) do
-    url
-  end
-  defp add_query(url, query, client) do
-    querystring = encode!(client, query, :query)
-    "#{url}?#{querystring}"
-  end
-
-  defp encode!(client, payload, format \\ :<%= context.encode %>) do
-    AWS.Client.encode!(client, payload, format)
-  end
-
-  defp decode!(client, payload) do
-    AWS.Client.decode!(client, payload, :<%= context.decode %>)
-  end
+      |> Request.build_params(input)<% else %>
+    query_params = []<% end %><%= if length(action.response_header_parameters) > 0 do %>
+    options = Keyword.put(
+      options,
+      :response_header_parameters,
+      <%= inspect((for param <- action.response_header_parameters, do: {param.location_name, param.name}), pretty: true) %>
+    )<% end %>
+    Request.request_rest(client, metadata(), <%= AWS.CodeGen.RestService.Action.method(action) %>, url_path, query_params, headers, input, options, <%= inspect(action.success_status_code) %>)<% end %>
+  end<% end %>
 end

--- a/test/aws_codegen/name_test.exs
+++ b/test/aws_codegen/name_test.exs
@@ -33,4 +33,10 @@ defmodule AWS.CodeGen.NameTest do
   test "to_snake_case/1 special cases UUID" do
     assert "uuid" = Name.to_snake_case("UUID")
   end
+
+  test "upcase_first/1" do
+    assert "Elixir" = Name.upcase_first("elixir")
+    assert "ElixirLang" = Name.upcase_first("elixirLang")
+    assert "IEx" = Name.upcase_first("iEx")
+  end
 end


### PR DESCRIPTION
This PR is in pair with https://github.com/aws-beam/aws-elixir/pull/51
It removes the code responsible for doing the request and treat the response for the Elixir code that is being generated.

The CI is fixed in another PR.