### PR TITLE
Skip body encoding when payload requires a binary

### DIFF
--- a/lib/aws_codegen/shapes.ex
+++ b/lib/aws_codegen/shapes.ex
@@ -1,0 +1,44 @@
+defmodule AWS.CodeGen.Shapes do
+  @moduledoc false
+
+  def get_input_shape(operation_spec) do
+    get_in(operation_spec, ["input", "shape"])
+  end
+
+  @doc """
+  It says if body should be encoded or not.
+
+  This is needed for requests like the S3's "put object", where
+  we need to send the raw body without encoding it.
+
+  ## Example
+
+      iex> shapes = %{
+      iex>   "Body" => %{"type" => "blob"},
+      iex>   "PutObjectRequest" => %{
+      iex>     "type" => "structure",
+      iex>     "members" => %{
+      iex>       "Body" => %{
+      iex>         "shape" => "Body",
+      iex>         "streaming" => true
+      iex>       }
+      iex>     }
+      iex>   }
+      iex> }
+      iex> input_shape = %{"shape" => "PutObjectRequest"}
+      iex> AWS.CodeGen.Shapes.send_body_as_binary?(shapes, input_shape)
+      true
+
+  """
+  def send_body_as_binary?(shapes, input_shape) do
+    with %{"shape" => inner_shape} = inner_spec <-
+           get_in(shapes, [input_shape, "members", "Body"]),
+         true <- !Map.has_key?(IO.inspect(inner_spec, label: "inner shape"), "location"),
+         %{"type" => type} <- Map.get(shapes, inner_shape) do
+      type in ~w(blob string)
+    else
+      _ ->
+        false
+    end
+  end
+end

--- a/lib/aws_codegen/shapes.ex
+++ b/lib/aws_codegen/shapes.ex
@@ -5,35 +5,10 @@ defmodule AWS.CodeGen.Shapes do
     get_in(operation_spec, ["input", "shape"])
   end
 
-  @doc """
-  It says if body should be encoded or not.
-
-  This is needed for requests like the S3's "put object", where
-  we need to send the raw body without encoding it.
-
-  ## Example
-
-      iex> shapes = %{
-      iex>   "Body" => %{"type" => "blob"},
-      iex>   "PutObjectRequest" => %{
-      iex>     "type" => "structure",
-      iex>     "members" => %{
-      iex>       "Body" => %{
-      iex>         "shape" => "Body",
-      iex>         "streaming" => true
-      iex>       }
-      iex>     }
-      iex>   }
-      iex> }
-      iex> input_shape = %{"shape" => "PutObjectRequest"}
-      iex> AWS.CodeGen.Shapes.send_body_as_binary?(shapes, input_shape)
-      true
-
-  """
   def send_body_as_binary?(shapes, input_shape) do
     with %{"shape" => inner_shape} = inner_spec <-
            get_in(shapes, [input_shape, "members", "Body"]),
-         true <- !Map.has_key?(IO.inspect(inner_spec, label: "inner shape"), "location"),
+         true <- !Map.has_key?(inner_spec, "location"),
          %{"type" => type} <- Map.get(shapes, inner_shape) do
       type in ~w(blob string)
     else

--- a/priv/rest.erl.eex
+++ b/priv/rest.erl.eex
@@ -129,8 +129,8 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Payload =
       case proplists:get_value(should_send_body_as_binary, Options) of
         true ->
-          maps:get_value(<<"Body">>, Input);
-        _ ->
+          maps:get(<<"Body">>, Input, <<"">>);
+        undefined ->
           encode_payload(Input)
       end,
 

--- a/priv/rest.erl.eex
+++ b/priv/rest.erl.eex
@@ -83,7 +83,7 @@
     Query_ = [],
     Input = Input1,
 <% end %><%= if length(action.response_header_parameters) > 0 do %>
-    case request(Client, Method, Path, Query_, Headers, Input, Options, SuccessStatusCode) of
+    case request(Client, Method, Path, Query_, Headers, Input, Options<%= if action.send_body_as_binary? do %> ++ [{should_send_body_as_binary, true}]<% end %>, SuccessStatusCode) of
       {ok, Body0, {_, ResponseHeaders, _} = Response} ->
         ResponseHeadersParams =
           [<%= for parameter <- Enum.drop action.response_header_parameters, -1 do %>
@@ -101,7 +101,7 @@
       Result ->
         Result
     end.<% else %>
-    request(Client, Method, Path, Query_, Headers, Input, Options, SuccessStatusCode).<% end %>
+    request(Client, Method, Path, Query_, Headers, Input, Options<%= if action.send_body_as_binary? do %> ++ [{should_send_body_as_binary, true}]<% end %>, SuccessStatusCode).<% end %>
 <% end %><% end %>
 %%====================================================================
 %% Internal functions
@@ -125,7 +125,15 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
                         , {<<"Content-Type">>, <<"<%= context.content_type %>">>}
                         ],
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
-    Payload = encode_payload(Input),
+
+    Payload =
+      case proplists:get_value(should_send_body_as_binary, Options) of
+        true ->
+          maps:get_value(<<"Body">>, Input);
+        _ ->
+          encode_payload(Input)
+      end,
+
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),

--- a/priv/rest.ex.eex
+++ b/priv/rest.ex.eex
@@ -70,6 +70,15 @@ defmodule <%= context.module_name %> do
       :response_header_parameters,
       <%= inspect((for param <- action.response_header_parameters, do: {param.location_name, param.name}), pretty: true) %>
     )<% end %>
+
+    <%= if action.send_body_as_binary? do %>
+      options = Keyword.put(
+        options,
+        :send_body_as_binary?,
+        true
+      )
+    <% end %>
+
     Request.request_rest(client, metadata(), <%= AWS.CodeGen.RestService.Action.method(action) %>, url_path, query_params, headers, input, options, <%= inspect(action.success_status_code) %>)<% end %>
   end<% end %>
 end

--- a/priv/rest.ex.eex
+++ b/priv/rest.ex.eex
@@ -50,6 +50,7 @@ defmodule <%= context.module_name %> do
       :response_header_parameters,
       <%= inspect((for param <- action.response_header_parameters, do: {param.location_name, param.name}), pretty: true) %>
     )<% end %>
+
     Request.request_rest(client, metadata(), :get, url_path, query_params, headers, nil, options, <%= inspect(action.success_status_code) %>)<% else %>
   def <%= action.function_name %>(%Client{} = client<%= AWS.CodeGen.RestService.function_parameters(action) %>, input, options \\ []) do
     url_path = "<%= AWS.CodeGen.RestService.Action.url_path(action) %>"<%= if length(action.request_header_parameters) > 0 do %>

--- a/test/aws_codegen/shapes_test.exs
+++ b/test/aws_codegen/shapes_test.exs
@@ -1,0 +1,34 @@
+defmodule AWS.CodeGen.ShapesTest do
+  use ExUnit.Case
+  alias AWS.CodeGen.Shapes
+
+  test "send_body_as_binary?/2" do
+    shapes = %{
+      "Body" => %{"type" => "blob"},
+      "PutObjectRequest" => %{
+        "type" => "structure",
+        "members" => %{
+          "Body" => %{
+            "shape" => "Body",
+            "streaming" => true
+          }
+        }
+      },
+      "PutObjectAclRequest" => %{
+        "type" => "structure",
+        "members" => %{
+          "ACL" => %{
+            "shape" => "ObjectCannedACL",
+            "location" => "header",
+            "locationName" => "x-amz-acl"
+          }
+        }
+      }
+    }
+
+    assert Shapes.send_body_as_binary?(shapes, "PutObjectRequest")
+
+    refute Shapes.send_body_as_binary?(shapes, "PutObjectAclRequest")
+    refute Shapes.send_body_as_binary?(shapes, "AnotherShape")
+  end
+end


### PR DESCRIPTION
This is necessary to enable some operations like S3's "put object" to
send the payload as a binary (a string or an binary representing a
blob).

~A fix to Erlang REST template is coming soon~.