### PR TITLE
[#50] Use maps in the generated Erlang code to handle optional parameters

### DIFF
--- a/priv/rest.erl.eex
+++ b/priv/rest.erl.eex
@@ -4,7 +4,7 @@
 <%= if context.docstring != "%% @doc" do %><%= context.docstring %><% end %>
 -module(<%= context.module_name %>).
 
--export([<%= Enum.map(context.actions, fn(action) -> ["#{action.function_name}/#{action.arity - 1}", "#{action.function_name}/#{action.arity}"] end) |> List.flatten |> Enum.join(",\n         ") %>]).
+-export([<%= Enum.map(context.actions, fn(action) -> if action.method == "GET" do ["#{action.function_name}/#{action.arity - 3}"] else [] end ++ ["#{action.function_name}/#{action.arity - 1}", "#{action.function_name}/#{action.arity}"] end) |> List.flatten |> Enum.join(",\n         ") %>]).
 
 -include_lib("hackney/include/hackney_lib.hrl").
 
@@ -13,18 +13,23 @@
 %%====================================================================
 <%= for action <- context.actions do %>
 <%= action.docstring %><%= if action.method == "GET" do %>
-<%= action.function_name %>(Client<%= AWS.CodeGen.RestService.function_parameters(action) %>)
+<%= action.function_name %>(Client<%= AWS.CodeGen.RestService.required_function_parameters(action) %>)
   when is_map(Client) ->
-    <%= action.function_name %>(Client<%= AWS.CodeGen.RestService.function_parameters(action) %>, []).
-<%= action.function_name %>(Client<%= AWS.CodeGen.RestService.function_parameters(action) %>, Options)
-  when is_map(Client), is_list(Options) ->
+    <%= action.function_name %>(Client<%= AWS.CodeGen.RestService.required_function_parameters(action) %>, #{}, #{}).
+
+<%= action.function_name %>(Client<%= AWS.CodeGen.RestService.required_function_parameters(action) %>, QueryMap, HeadersMap)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
+    <%= action.function_name %>(Client<%= AWS.CodeGen.RestService.required_function_parameters(action) %>, QueryMap, HeadersMap, []).
+
+<%= action.function_name %>(Client<%= AWS.CodeGen.RestService.required_function_parameters(action) %>, QueryMap, HeadersMap, Options)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options) ->
     Path = ["<%= AWS.CodeGen.RestService.Action.url_path(action) %>"],
     SuccessStatusCode = <%= if is_nil(action.success_status_code), do: "undefined", else: inspect(action.success_status_code) %>,
 <%= if length(action.request_header_parameters) > 0 do %>
     Headers0 =
       [<%= for parameter <- Enum.drop(action.request_header_parameters, -1) do %>
-        {<<"<%= parameter.location_name %>">>, <%= parameter.code_name %>},<% end %><%= for parameter <- Enum.slice action.request_header_parameters, -1..-1 do %>
-        {<<"<%= parameter.location_name %>">>, <%= parameter.code_name %>}
+        {<<"<%= parameter.location_name %>">>, <%= if parameter.required do %><%= parameter.code_name %><% else %>maps:get(<<"<%= parameter.location_name %>">>, HeadersMap, undefined)<% end %>},<% end %><%= for parameter <- Enum.slice action.request_header_parameters, -1..-1 do %>
+        {<<"<%= parameter.location_name %>">>, <%= if parameter.required do %><%= parameter.code_name %><% else %>maps:get(<<"<%= parameter.location_name %>">>, HeadersMap, undefined)<% end %>}
       <% end %>],
     Headers = [H || {_, V} = H <- Headers0, V =/= undefined],
 <% else %>
@@ -32,8 +37,8 @@
 <% end %><%= if length(action.query_parameters) > 0 do %>
     Query0_ =
       [<%= for parameter <- Enum.drop(action.query_parameters, -1) do %>
-        {<<"<%= parameter.location_name %>">>, <%= parameter.code_name %>},<% end %><%= for parameter <- Enum.slice action.query_parameters, -1..-1 do %>
-        {<<"<%= parameter.location_name %>">>, <%= parameter.code_name %>}
+        {<<"<%= parameter.location_name %>">>, <%= if parameter.required do %><%= parameter.code_name %><% else %>maps:get(<<"<%= parameter.location_name %>">>, QueryMap, undefined)<% end %>},<% end %><%= for parameter <- Enum.slice action.query_parameters, -1..-1 do %>
+        {<<"<%= parameter.location_name %>">>, <%= if parameter.required do %><%= parameter.code_name %><% else %>maps:get(<<"<%= parameter.location_name %>">>, QueryMap, undefined)<% end %>}
       <% end %>],
     Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
 <% else %>


### PR DESCRIPTION
Currently, the generated Erlang code requires the user to pass *all* parameters (both the required and optional ones) to the respective functions, eventually using the `undefined` atom. As you can image, this makes the library useless for Erlang users when it comes to function which accept a significant number of arguments.

What I propose here is to use `maps` to pass the optional parameters, instead. Before investing too much time on it, I wanted to hear your opinion.

This PR allows to go from the current:

```
get_object(Client, Bucket, Key, PartNumber, ResponseCacheControl, ResponseContentDisposition, ResponseContentEncoding, ResponseContentLanguage, ResponseContentType, ResponseExpires, VersionId, ExpectedBucketOwner, IfMatch, IfModifiedSince, IfNoneMatch, IfUnmodifiedSince, Range, RequestPayer, SSECustomerAlgorithm, SSECustomerKey, SSECustomerKeyMD5)
  when is_map(Client) ->
    get_object(Client, Bucket, Key, PartNumber, ResponseCacheControl, ResponseContentDisposition, ResponseContentEncoding, ResponseContentLanguage, ResponseContentType, ResponseExpires, VersionId, ExpectedBucketOwner, IfMatch, IfModifiedSince, IfNoneMatch, IfUnmodifiedSince, Range, RequestPayer, SSECustomerAlgorithm, SSECustomerKey, SSECustomerKeyMD5, []).
get_object(Client, Bucket, Key, PartNumber, ResponseCacheControl, ResponseContentDisposition, ResponseContentEncoding, ResponseContentLanguage, ResponseContentType, ResponseExpires, VersionId, ExpectedBucketOwner, IfMatch, IfModifiedSince, IfNoneMatch, IfUnmodifiedSince, Range, RequestPayer, SSECustomerAlgorithm, SSECustomerKey, SSECustomerKeyMD5, Options)
  when is_map(Client), is_list(Options) ->
    Path = ["/", aws_util:encode_uri(Bucket), "/", aws_util:encode_multi_segment_uri(Key), ""],
    SuccessStatusCode = undefined,

    Headers0 =
      [
        {<<"x-amz-expected-bucket-owner">>, ExpectedBucketOwner},
        [...]
      ],
    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],

    Query0_ =
      [
        {<<"partNumber">>, PartNumber},
        [...]
      ],
    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],

    [...]
 ```
 
 To a slightly more user friendly:
 
 ```
 get_object(Client, Bucket, Key)
  when is_map(Client) ->
    get_object(Client, Bucket, Key, #{}, #{}).

get_object(Client, Bucket, Key, QueryMap, HeadersMap)
  when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
    get_object(Client, Bucket, Key, QueryMap, HeadersMap, []).

get_object(Client, Bucket, Key, QueryMap, HeadersMap, Options)
  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options) ->
    Path = ["/", aws_util:encode_uri(Bucket), "/", aws_util:encode_multi_segment_uri(Key), ""],
    SuccessStatusCode = undefined,

    Headers0 =
      [
        {<<"x-amz-expected-bucket-owner">>, maps:get(<<"x-amz-expected-bucket-owner">>, HeadersMap, undefined)},
        [...]
      ],
    Headers = [H || {_, V} = H <- Headers0, V =/= undefined],

    Query0_ =
      [
        {<<"partNumber">>, maps:get(<<"partNumber">>, QueryMap, undefined)},
        [...]
      ],
    Query_ = [H || {_, V} = H <- Query0_, V =/= undefined],
    
    [...]
 ```
 
 A few considerations:
 
 * This is my first contribution to the project and my first Elixir code, so there's a high chance that my code is not very idiomatic, if that's the case please advise
 * The generated code won't be backward compatible with previous versions of the library
 * This is totally untested. Is there any way for me to run some tests?
 * I'm not sure whether _header parameters_ can even be required. If they're not, the code can be further simplified.
 * I'm only changing the `rest` module for now.