### PR TITLE
[#67] Do not decode binary response body

### DIFF
--- a/lib/aws_codegen/rest_service.ex
+++ b/lib/aws_codegen/rest_service.ex
@@ -20,6 +20,7 @@ defmodule AWS.CodeGen.RestService do
               required_request_header_parameters: [],
               response_header_parameters: [],
               send_body_as_binary?: false,
+              receive_body_as_binary?: false,
               language: nil
 
     def method(action) do
@@ -219,6 +220,7 @@ defmodule AWS.CodeGen.RestService do
         end
 
       input_shape = Shapes.get_input_shape(operation_spec)
+      output_shape = Shapes.get_output_shape(operation_spec)
 
       %Action{
         arity: length(url_parameters) + len_for_method,
@@ -239,7 +241,8 @@ defmodule AWS.CodeGen.RestService do
         required_request_header_parameters: required_request_header_parameters,
         response_header_parameters:
           collect_response_header_parameters(language, api_spec, operation),
-        send_body_as_binary?: Shapes.send_body_as_binary?(shapes, input_shape),
+        send_body_as_binary?: Shapes.body_as_binary?(shapes, input_shape),
+        receive_body_as_binary?: Shapes.body_as_binary?(shapes, output_shape),
         language: language
       }
     end)

--- a/lib/aws_codegen/shapes.ex
+++ b/lib/aws_codegen/shapes.ex
@@ -9,9 +9,9 @@ defmodule AWS.CodeGen.Shapes do
     get_in(operation_spec, ["output", "shape"])
   end
 
-  def body_as_binary?(shapes, input_shape) do
+  def body_as_binary?(shapes, shape) do
     with %{"shape" => inner_shape} = inner_spec <-
-           get_in(shapes, [input_shape, "members", "Body"]),
+           get_in(shapes, [shape, "members", "Body"]),
          true <- !Map.has_key?(inner_spec, "location"),
          %{"type" => type} <- Map.get(shapes, inner_shape) do
       type in ~w(blob string)

--- a/lib/aws_codegen/shapes.ex
+++ b/lib/aws_codegen/shapes.ex
@@ -5,7 +5,11 @@ defmodule AWS.CodeGen.Shapes do
     get_in(operation_spec, ["input", "shape"])
   end
 
-  def send_body_as_binary?(shapes, input_shape) do
+  def get_output_shape(operation_spec) do
+    get_in(operation_spec, ["output", "shape"])
+  end
+
+  def body_as_binary?(shapes, input_shape) do
     with %{"shape" => inner_shape} = inner_spec <-
            get_in(shapes, [input_shape, "members", "Body"]),
          true <- !Map.has_key?(inner_spec, "location"),

--- a/priv/rest.erl.eex
+++ b/priv/rest.erl.eex
@@ -21,10 +21,13 @@
   when is_map(Client), is_map(QueryMap), is_map(HeadersMap) ->
     <%= action.function_name %>(Client<%= AWS.CodeGen.RestService.required_function_parameters(action) %>, QueryMap, HeadersMap, []).
 
-<%= action.function_name %>(Client<%= AWS.CodeGen.RestService.required_function_parameters(action) %>, QueryMap, HeadersMap, Options)
-  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options) ->
+<%= action.function_name %>(Client<%= AWS.CodeGen.RestService.required_function_parameters(action) %>, QueryMap, HeadersMap, Options0)
+  when is_map(Client), is_map(QueryMap), is_map(HeadersMap), is_list(Options0) ->
     Path = ["<%= AWS.CodeGen.RestService.Action.url_path(action) %>"],
     SuccessStatusCode = <%= if is_nil(action.success_status_code), do: "undefined", else: inspect(action.success_status_code) %>,
+    Options = [{send_body_as_binary, <%= action.send_body_as_binary? %>},
+               {receive_body_as_binary, <%= action.receive_body_as_binary? %>}
+               | Options0],
 <%= if length(action.request_header_parameters) > 0 do %>
     Headers0 =
       [<%= for parameter <- Enum.drop(action.request_header_parameters, -1) do %>
@@ -66,10 +69,14 @@
 <% else %>
 <%= action.function_name %>(Client<%= AWS.CodeGen.RestService.function_parameters(action) %>, Input) ->
     <%= action.function_name %>(Client<%= AWS.CodeGen.RestService.function_parameters(action) %>, Input, []).
-<%= action.function_name %>(Client<%= AWS.CodeGen.RestService.function_parameters(action) %>, Input0, Options) ->
+<%= action.function_name %>(Client<%= AWS.CodeGen.RestService.function_parameters(action) %>, Input0, Options0) ->
     Method = <%= AWS.CodeGen.RestService.Action.method(action) %>,
     Path = ["<%= AWS.CodeGen.RestService.Action.url_path(action) %>"],
     SuccessStatusCode = <%= if is_nil(action.success_status_code), do: "undefined", else: inspect(action.success_status_code) %>,
+    Options = [{send_body_as_binary, <%= action.send_body_as_binary? %>},
+               {receive_body_as_binary, <%= action.receive_body_as_binary? %>}
+               | Options0],
+
 <%= if length(action.request_header_parameters) > 0 do %>
     HeadersMapping = [<%= for parameter <- Enum.drop(action.request_header_parameters, -1) do %>
                        {<<"<%= parameter.location_name %>">>, <<"<%= parameter.name %>">>},<% end %><%= for parameter <- Enum.slice action.request_header_parameters, -1..-1 do %>
@@ -88,7 +95,7 @@
     Query_ = [],
     Input = Input1,
 <% end %><%= if length(action.response_header_parameters) > 0 do %>
-    case request(Client, Method, Path, Query_, Headers, Input, Options<%= if action.send_body_as_binary? do %> ++ [{should_send_body_as_binary, true}]<% end %>, SuccessStatusCode) of
+    case request(Client, Method, Path, Query_, Headers, Input, Options, SuccessStatusCode) of
       {ok, Body0, {_, ResponseHeaders, _} = Response} ->
         ResponseHeadersParams =
           [<%= for parameter <- Enum.drop action.response_header_parameters, -1 do %>
@@ -106,7 +113,7 @@
       Result ->
         Result
     end.<% else %>
-    request(Client, Method, Path, Query_, Headers, Input, Options<%= if action.send_body_as_binary? do %> ++ [{should_send_body_as_binary, true}]<% end %>, SuccessStatusCode).<% end %>
+    request(Client, Method, Path, Query_, Headers, Input, Options, SuccessStatusCode).<% end %>
 <% end %><% end %>
 %%====================================================================
 %% Internal functions
@@ -132,19 +139,20 @@ request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusCode
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
 
     Payload =
-      case proplists:get_value(should_send_body_as_binary, Options) of
+      case proplists:get_value(send_body_as_binary, Options) of
         true ->
           maps:get(<<"Body">>, Input, <<"">>);
-        undefined ->
+        false ->
           encode_payload(Input)
       end,
 
     MethodBin = aws_request:method_to_binary(Method),
     SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),
-    handle_response(Response, SuccessStatusCode).
+    DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
+    handle_response(Response, SuccessStatusCode, DecodeBody).
 
-handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode)
+handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, DecodeBody)
   when StatusCode =:= 200;
        StatusCode =:= 202;
        StatusCode =:= 204;
@@ -154,14 +162,17 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode)
                         StatusCode =:= SuccessStatusCode ->
             {ok, #{}, {StatusCode, ResponseHeaders, Client}};
         {ok, Body} ->
-            Result = <%= context.decode %>,
+            Result = case DecodeBody of
+                       true -> <%= context.decode %>;
+                       false -> #{<<"Body">> => Body}
+                     end,
             {ok, Result, {StatusCode, ResponseHeaders, Client}}
     end;
-handle_response({ok, StatusCode, ResponseHeaders, Client}, _) ->
+handle_response({ok, StatusCode, ResponseHeaders, Client}, _, _DecodeBody) ->
     {ok, Body} = hackney:body(Client),
     Error = <%= context.decode %>,
     {error, Error, {StatusCode, ResponseHeaders, Client}};
-handle_response({error, Reason}, _) ->
+handle_response({error, Reason}, _, _DecodeBody) ->
   {error, Reason}.
 <%= if context.endpoint_prefix == "s3-control" do %>
 build_host(_AccountId, _EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->

--- a/test/aws_codegen/shapes_test.exs
+++ b/test/aws_codegen/shapes_test.exs
@@ -2,7 +2,7 @@ defmodule AWS.CodeGen.ShapesTest do
   use ExUnit.Case
   alias AWS.CodeGen.Shapes
 
-  test "send_body_as_binary?/2" do
+  test "body_as_binary?/2" do
     shapes = %{
       "Body" => %{"type" => "blob"},
       "PutObjectRequest" => %{
@@ -26,9 +26,9 @@ defmodule AWS.CodeGen.ShapesTest do
       }
     }
 
-    assert Shapes.send_body_as_binary?(shapes, "PutObjectRequest")
+    assert Shapes.body_as_binary?(shapes, "PutObjectRequest")
 
-    refute Shapes.send_body_as_binary?(shapes, "PutObjectAclRequest")
-    refute Shapes.send_body_as_binary?(shapes, "AnotherShape")
+    refute Shapes.body_as_binary?(shapes, "PutObjectAclRequest")
+    refute Shapes.body_as_binary?(shapes, "AnotherShape")
   end
 end


### PR DESCRIPTION
Emulating the approach in #62 , this PR skips decoding of the response body for those methods where the body is a binary.
Since my Elixir knowledge is quite limited, please advise on the change for the Elixir generated code (currently not included in this PR).