### PR TITLE
Add support for S3 metadata

### DIFF
--- a/lib/aws_codegen/rest_service.ex
+++ b/lib/aws_codegen/rest_service.ex
@@ -17,6 +17,7 @@ defmodule AWS.CodeGen.RestService do
               query_parameters: [],
               required_query_parameters: [],
               request_header_parameters: [],
+              request_headers_parameters: [],
               required_request_header_parameters: [],
               response_header_parameters: [],
               send_body_as_binary?: false,
@@ -157,9 +158,9 @@ defmodule AWS.CodeGen.RestService do
               false ->
                 [
                   join_parameters(action.query_parameters, language),
-                  join_parameters(action.request_header_parameters, language)
+                  join_parameters(action.request_header_parameters, language),
+                  join_parameters(action.request_headers_parameters, language)
                 ]
-
               true ->
                 [
                   join_parameters(action.required_query_parameters, language),
@@ -197,6 +198,7 @@ defmodule AWS.CodeGen.RestService do
       url_parameters = collect_url_parameters(language, api_spec, operation)
       query_parameters = collect_query_parameters(language, api_spec, operation)
       request_header_parameters = collect_request_header_parameters(language, api_spec, operation)
+      request_headers_parameters = collect_request_headers_parameters(language, api_spec, operation)
       is_required = fn param -> param.required end
       required_query_parameters = Enum.filter(query_parameters, is_required)
       required_request_header_parameters = Enum.filter(request_header_parameters, is_required)
@@ -207,8 +209,7 @@ defmodule AWS.CodeGen.RestService do
           "GET" ->
             case language do
               :elixir ->
-                2 + length(request_header_parameters) + length(query_parameters)
-
+                2 + length(request_header_parameters) + length(request_headers_parameters) + length(query_parameters)
               :erlang ->
                 4 + length(required_request_header_parameters) + length(required_query_parameters)
             end
@@ -236,6 +237,7 @@ defmodule AWS.CodeGen.RestService do
         query_parameters: query_parameters,
         required_query_parameters: required_query_parameters,
         request_header_parameters: request_header_parameters,
+        request_headers_parameters: request_headers_parameters,
         required_request_header_parameters: required_request_header_parameters,
         response_header_parameters:
           collect_response_header_parameters(language, api_spec, operation),
@@ -257,6 +259,10 @@ defmodule AWS.CodeGen.RestService do
 
   defp collect_request_header_parameters(language, api_spec, operation) do
     collect_parameters(language, api_spec, operation, "input", "header")
+  end
+
+  defp collect_request_headers_parameters(language, api_spec, operation) do
+    collect_parameters(language, api_spec, operation, "input", "headers")
   end
 
   defp collect_response_header_parameters(language, api_spec, operation) do

--- a/priv/rest.erl.eex
+++ b/priv/rest.erl.eex
@@ -86,16 +86,25 @@
 <% else %>
     Headers = [],
     Input1 = Input0,
+<% end %><%= if length(action.request_headers_parameters) > 0 do %>
+    CustomHeadersMapping = [<%= for parameter <- Enum.drop(action.request_headers_parameters, -1) do %>
+                             {<<"<%= parameter.location_name %>">>, <<"<%= parameter.name %>">>},<% end %><%= for parameter <- Enum.slice action.request_headers_parameters, -1..-1 do %>
+                             {<<"<%= parameter.location_name %>">>, <<"<%= parameter.name %>">>}
+                          <% end %>],
+    {CustomHeaders, Input2} = aws_request:build_custom_headers(CustomHeadersMapping, Input1),
+<% else %>
+    CustomHeaders = [],
+    Input2 = Input1,
 <% end %><%= if length(action.query_parameters) > 0 do %>
     QueryMapping = [<%= for parameter <- Enum.drop(action.query_parameters, -1) do %>
                      {<<"<%= parameter.location_name %>">>, <<"<%= parameter.name %>">>},<% end %><%= for parameter <- Enum.slice action.query_parameters, -1..-1 do %>
                      {<<"<%= parameter.location_name %>">>, <<"<%= parameter.name %>">>}
                    <% end %>],
-    {Query_, Input} = aws_request:build_headers(QueryMapping, Input1),<% else %>
+    {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),<% else %>
     Query_ = [],
-    Input = Input1,
+    Input = Input2,
 <% end %><%= if length(action.response_header_parameters) > 0 do %>
-    case request(Client, Method, Path, Query_, Headers, Input, Options, SuccessStatusCode) of
+    case request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode) of
       {ok, Body0, {_, ResponseHeaders, _} = Response} ->
         ResponseHeadersParams =
           [<%= for parameter <- Enum.drop action.response_header_parameters, -1 do %>
@@ -113,7 +122,7 @@
       Result ->
         Result
     end.<% else %>
-    request(Client, Method, Path, Query_, Headers, Input, Options, SuccessStatusCode).<% end %>
+    request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode).<% end %>
 <% end %><% end %>
 %%====================================================================
 %% Internal functions


### PR DESCRIPTION
As part of the API specification, some input parameters can have the location set to `headers` (as opposed to the typical `header`). From what I can tell, this feature is currently used for the _S3_ service only.

The `headers` location type specifies a _prefix_ that can be used by clients to pass custom headers. For example, in S3, given the parameter:

```
        "Metadata":{
          "shape":"Metadata",
          "location":"headers",
          "locationName":"x-amz-meta-"
        },
```

Users can specify metadata for uploaded files, as following:

```
aws_s3:put_object(Client, Bucket, Key, #{<<"Body">> => Body, <<"Metadata">> => #{<<"my-key">> => <<"1">>, <<"my_other_key">> => <<"2">>}}).
```

Which will then be translated into the headers:

```
x-amz-meta-my-key
x-amz-meta-my-other-key
```

Right now `headers` parameters are ignored, so users are not able to specify them. This PR adds support for `headers` input parameters and, therefore, for S3 metadata.

For now I only addressed the Erlang side. It would be good if some Elixir member could take that part, otherwise I will attempt it as a follow up.