### PR TITLE
Fix return value of HEAD requests and fix type spec of request/8

### DIFF
--- a/priv/rest.erl.eex
+++ b/priv/rest.erl.eex
@@ -105,7 +105,8 @@
     Input = Input2,
 <% end %><%= if length(action.response_header_parameters) > 0 do %>
     case request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode) of
-      {ok, Body0, {_, ResponseHeaders, _} = Response} ->
+      <%= if AWS.CodeGen.RestService.Action.method(action) == "head" do %>{ok, {_, ResponseHeaders} = Response} ->
+        Body0 = #{},<% else %>{ok, Body0, {_, ResponseHeaders, _} = Response} -><% end %>
         ResponseHeadersParams =
           [<%= for parameter <- Enum.drop action.response_header_parameters, -1 do %>
             {<<"<%= parameter.location_name %>">>, <<"<%= parameter.name %>">>},<% end %><%= for parameter <- Enum.slice action.response_header_parameters, -1..-1 do %>
@@ -130,6 +131,7 @@
 
 -spec request(aws_client:aws_client(), atom(), iolist(), list(),
               list(), map() | undefined, list(), pos_integer() | undefined) ->
+    {ok, {integer(), list()}} |
     {ok, Result, {integer(), list(), hackney:client()}} |
     {error, Error, {integer(), list(), hackney:client()}} |
     {error, term()} when


### PR DESCRIPTION
This actually showed up due to Dialyzer indicating us that this was wrong in our code. Even if Dialyzer was run (which it isn't) on `aws-erlang` it may or may not have caught it since a catch-all type of clause exists there. 

Diff that it generates for `aws_s3` 
```diff
diff --git a/src/aws_s3.erl b/src/aws_s3.erl
index 430212f..8829dde 100644
--- a/src/aws_s3.erl
+++ b/src/aws_s3.erl
@@ -3760,7 +3760,8 @@ head_object(Client, Bucket, Key, Input0, Options0) ->
                    ],
     {Query_, Input} = aws_request:build_headers(QueryMapping, Input2),
     case request(Client, Method, Path, Query_, CustomHeaders ++ Headers, Input, Options, SuccessStatusCode) of
-      {ok, Body0, {_, ResponseHeaders, _} = Response} ->
+      {ok, {_, ResponseHeaders} = Response} ->
+        Body0 = #{},
         ResponseHeadersParams =
           [
             {<<"accept-ranges">>, <<"AcceptRanges">>},
@@ -7407,6 +7408,7 @@ write_get_object_response(Client, Input0, Options0) ->

 -spec request(aws_client:aws_client(), atom(), iolist(), list(),
               list(), map() | undefined, list(), pos_integer() | undefined) ->
+    {ok, {integer(), list()}} |
     {ok, Result, {integer(), list(), hackney:client()}} |
     {error, Error, {integer(), list(), hackney:client()}} |
     {error, term()} when
     ```