### PR TITLE
Add nightly builds for aws-erlang and aws-elixir

### DIFF
--- a/.github/workflows/nightly-elixir.yml
+++ b/.github/workflows/nightly-elixir.yml
@@ -9,23 +9,23 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container:
-      image: hexpm/elixir:${{ matrix.elixir }}-erlang-${{ matrix.erlang }}-ubuntu-${{ matrix.ubuntu }}
-
-    name: Elixir ${{ matrix.elixir }} / Erlang ${{ matrix.erlang }} with Ubuntu ${{matrix.ubuntu}}
+    name: Elixir ${{ matrix.elixir }} with Ubuntu ${{matrix.ubuntu}}
 
     strategy:
       fail-fast: false
       matrix:
-        elixir: ["1.11.2"]
         erlang: ["23.1.4"]
+        elixir: ["1.11.2"]
         ubuntu: ["focal-20201008"]
     steps:
       - uses: actions/checkout@v2
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{matrix.erlang}}
+          elixir-version: ${{matrix.elixir}}
+          rebar3-version: '3.16.1'
       - name: Install Dependencies
         run: |
-          apt-get update
-          DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install build-essential cmake git ca-certificates
           mix local.rebar --force
           mix local.hex --force
           mix deps.get
@@ -38,29 +38,30 @@ jobs:
       - name: Checkout aws-elixir
         uses: actions/checkout@v2
         with:
-          repository: aws-beam/aws-elixir
-          path: aws-beam/aws-elixir
+          repository: onno-vos-dev/aws-elixir
+          path: onno-vos-dev/aws-elixir
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       - name: Generate aws-elixir
         env:
           SPEC_PATH: aws/aws-sdk-go/models/apis
           TEMPLATE_PATH: priv
-          ELIXIR_OUTPUT_PATH: aws-beam/aws-elixir/lib/aws/generated
+          ELIXIR_OUTPUT_PATH: onno-vos-dev/aws-elixir/lib/aws/generated
         run: |
           mkdir -p $ELIXIR_OUTPUT_PATH
           mix run generate.exs elixir $SPEC_PATH $TEMPLATE_PATH $ELIXIR_OUTPUT_PATH
       - name: Commit files
         run: |
+          OLD_PATH=$(pwd)
           cd aws/aws-sdk-go/
           git fetch --tags
           LATEST_TAG=$(git describe --tags --abbrev=0)
-          cd ../../
+          cd $OLD_PATH
           cd onno-vos-dev/aws-elixir
           [[ -f latest-tag-aws-sdk-go ]] && LATEST_TAG_BUILT=$(<latest-tag-aws-sdk-go) || LATEST_TAG_BUILT=''
           if [ "$LATEST_TAG_BUILT" != "$LATEST_TAG" ] || [ "$LATEST_TAG_BUILT" == "$LATEST_TAG" ]
           then
-            git config --local user.email "aws-elixir@github.com"
-            git config --local user.name "AWS Elixir"
+            git config --local user.email "actions@github.com"
+            git config --local user.name "GitHub Actions"
             git add lib/aws/generated/*
             if [ -n "$(git status --porcelain)" ]
             then
@@ -73,6 +74,6 @@ jobs:
         uses: ad-m/github-push-action@v0.6.0
         with:
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          repository: aws-beam/aws-elixir
+          repository: onno-vos-dev/aws-elixir
           branch: master
-          directory: aws-beam/aws-elixir
+          directory: onno-vos-dev/aws-elixir

--- a/.github/workflows/nightly-elixir.yml
+++ b/.github/workflows/nightly-elixir.yml
@@ -1,0 +1,68 @@
+name: Push generated aws-elixir code
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: '23 0 * * *' ## Scheduled nightly at 00:23
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: hexpm/elixir:${{ matrix.elixir }}-erlang-${{ matrix.erlang }}-ubuntu-${{ matrix.ubuntu }}
+
+    name: Elixir ${{ matrix.elixir }} / Erlang ${{ matrix.erlang }} with Ubuntu ${{matrix.ubuntu}}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        elixir: ["1.11.2"]
+        erlang: ["23.1.4"]
+        ubuntu: ["focal-20201008"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Dependencies
+        run: |
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install build-essential cmake git ca-certificates
+          mix local.rebar --force
+          mix local.hex --force
+          mix deps.get
+      - name: Checkout aws/aws-sdk-go
+        uses: actions/checkout@v2
+        with:
+          repository: aws/aws-sdk-go
+          path: aws/aws-sdk-go/
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      - name: Checkout aws-elixir
+        uses: actions/checkout@v2
+        with:
+          repository: aws-beam/aws-elixir
+          path: aws-beam/aws-elixir
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      - name: Generate aws-elixir
+        env:
+          SPEC_PATH: aws/aws-sdk-go/models/apis
+          TEMPLATE_PATH: priv
+          ELIXIR_OUTPUT_PATH: aws-beam/aws-elixir/lib/aws/generated
+        run: |
+          mkdir -p $ELIXIR_OUTPUT_PATH
+          mix run generate.exs elixir $SPEC_PATH $TEMPLATE_PATH $ELIXIR_OUTPUT_PATH
+      - name: Commit files
+        run: |
+          cd aws-beam/aws-elixir
+          git config --local user.email "aws-elixir@github.com"
+          git config --local user.name "AWS Elixir"
+          git add lib/aws/generated/*
+          if [ -n "$(git status --porcelain)" ]
+          then
+            git commit -m "Update generated code"
+          fi
+      - name: Push changes
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          repository: aws-beam/aws-elixir
+          branch: master
+          directory: aws-beam/aws-elixir

--- a/.github/workflows/nightly-elixir.yml
+++ b/.github/workflows/nightly-elixir.yml
@@ -51,13 +51,23 @@ jobs:
           mix run generate.exs elixir $SPEC_PATH $TEMPLATE_PATH $ELIXIR_OUTPUT_PATH
       - name: Commit files
         run: |
-          cd aws-beam/aws-elixir
-          git config --local user.email "aws-elixir@github.com"
-          git config --local user.name "AWS Elixir"
-          git add lib/aws/generated/*
-          if [ -n "$(git status --porcelain)" ]
+          cd aws/aws-sdk-go/
+          git fetch --tags
+          LATEST_TAG=$(git describe --tags --abbrev=0)
+          cd ../../
+          cd onno-vos-dev/aws-elixir
+          [[ -f latest-tag-aws-sdk-go ]] && LATEST_TAG_BUILT=$(<latest-tag-aws-sdk-go) || LATEST_TAG_BUILT=''
+          if [ "$LATEST_TAG_BUILT" != "$LATEST_TAG" ] || [ "$LATEST_TAG_BUILT" == "$LATEST_TAG" ]
           then
-            git commit -m "Update generated code"
+            git config --local user.email "aws-elixir@github.com"
+            git config --local user.name "AWS Elixir"
+            git add lib/aws/generated/*
+            if [ -n "$(git status --porcelain)" ]
+            then
+              echo $LATEST_TAG > latest-tag-aws-sdk-go
+              git add latest-tag-aws-sdk-go
+              git commit -m "Update generated code - aws-sdk-go version: $LATEST_TAG"
+            fi
           fi
       - name: Push changes
         uses: ad-m/github-push-action@v0.6.0

--- a/.github/workflows/nightly-erlang.yml
+++ b/.github/workflows/nightly-erlang.yml
@@ -54,13 +54,23 @@ jobs:
         working-directory: aws-beam/aws-erlang
       - name: Commit files
         run: |
+          cd aws/aws-sdk-go/
+          git fetch --tags
+          LATEST_TAG=$(git describe --tags --abbrev=0)
+          cd ../../
           cd aws-beam/aws-erlang
-          git config --local user.email "aws-erlang@github.com"
-          git config --local user.name "AWS Erlang"
-          git add src/*
-          if [ -n "$(git status --porcelain)" ]
+          [[ -f latest-tag-aws-sdk-go ]] && LATEST_TAG_BUILT=$(<latest-tag-aws-sdk-go) || LATEST_TAG_BUILT=''
+          if [ "$LATEST_TAG_BUILT" != "$LATEST_TAG" ] || [ "$LATEST_TAG_BUILT" == "$LATEST_TAG" ]
           then
-            git commit -m "Update generated code"
+            git config --local user.email "aws-erlang@github.com"
+            git config --local user.name "AWS Erlang"
+            git add src/*
+            if [ -n "$(git status --porcelain)" ]
+            then
+              echo $LATEST_TAG > latest-tag-aws-sdk-go
+              git add latest-tag-aws-sdk-go
+              git commit -m "Update generated code - aws-sdk-go version: $LATEST_TAG"
+            fi
           fi
       - name: Push changes
         uses: ad-m/github-push-action@v0.6.0

--- a/.github/workflows/nightly-erlang.yml
+++ b/.github/workflows/nightly-erlang.yml
@@ -1,0 +1,71 @@
+name: Push generated aws-erlang code
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: '23 0 * * *' ## Scheduled nightly at 00:23
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: hexpm/elixir:${{ matrix.elixir }}-erlang-${{ matrix.erlang }}-ubuntu-${{ matrix.ubuntu }}
+
+    name: Elixir ${{ matrix.elixir }} / Erlang ${{ matrix.erlang }} with Ubuntu ${{matrix.ubuntu}}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        elixir: ["1.11.2"]
+        erlang: ["23.1.4"]
+        ubuntu: ["focal-20201008"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Dependencies
+        run: |
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install build-essential cmake git ca-certificates
+          mix local.rebar --force
+          mix local.hex --force
+          mix deps.get
+      - name: Checkout aws/aws-sdk-go
+        uses: actions/checkout@v2
+        with:
+          repository: aws/aws-sdk-go
+          path: aws/aws-sdk-go/
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      - name: Checkout aws-erlang
+        uses: actions/checkout@v2
+        with:
+          repository: aws-beam/aws-erlang
+          path: aws-beam/aws-erlang
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      - name: Generate aws-erlang
+        env:
+          SPEC_PATH: aws/aws-sdk-go/models/apis
+          TEMPLATE_PATH: priv
+          ERLANG_OUTPUT_PATH: aws-beam/aws-erlang/src
+        run: mix run generate.exs erlang $SPEC_PATH $TEMPLATE_PATH $ERLANG_OUTPUT_PATH
+      - name: Install a local copy of rebar3
+        run: mix local.rebar rebar3 aws-beam/aws-erlang
+      - name: Run Erlang tests
+        run: ./rebar3 eunit
+        working-directory: aws-beam/aws-erlang
+      - name: Commit files
+        run: |
+          cd aws-beam/aws-erlang
+          git config --local user.email "aws-erlang@github.com"
+          git config --local user.name "AWS Erlang"
+          git add src/*
+          if [ -n "$(git status --porcelain)" ]
+          then
+            git commit -m "Update generated code"
+          fi
+      - name: Push changes
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          repository: aws-beam/aws-erlang
+          branch: master
+          directory: aws-beam/aws-erlang

--- a/.github/workflows/nightly-erlang.yml
+++ b/.github/workflows/nightly-erlang.yml
@@ -9,23 +9,23 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container:
-      image: hexpm/elixir:${{ matrix.elixir }}-erlang-${{ matrix.erlang }}-ubuntu-${{ matrix.ubuntu }}
-
-    name: Elixir ${{ matrix.elixir }} / Erlang ${{ matrix.erlang }} with Ubuntu ${{matrix.ubuntu}}
+    name: Erlang ${{ matrix.erlang }} with Ubuntu ${{matrix.ubuntu}}
 
     strategy:
       fail-fast: false
       matrix:
-        elixir: ["1.11.2"]
         erlang: ["23.1.4"]
+        elixir: ["1.11.2"]
         ubuntu: ["focal-20201008"]
     steps:
       - uses: actions/checkout@v2
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{matrix.erlang}}
+          elixir-version: ${{matrix.elixir}}
+          rebar3-version: '3.16.1'
       - name: Install Dependencies
         run: |
-          apt-get update
-          DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install build-essential cmake git ca-certificates
           mix local.rebar --force
           mix local.hex --force
           mix deps.get
@@ -38,32 +38,33 @@ jobs:
       - name: Checkout aws-erlang
         uses: actions/checkout@v2
         with:
-          repository: aws-beam/aws-erlang
-          path: aws-beam/aws-erlang
+          repository: onno-vos-dev/aws-erlang
+          path: onno-vos-dev/aws-erlang
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       - name: Generate aws-erlang
         env:
           SPEC_PATH: aws/aws-sdk-go/models/apis
           TEMPLATE_PATH: priv
-          ERLANG_OUTPUT_PATH: aws-beam/aws-erlang/src
+          ERLANG_OUTPUT_PATH: onno-vos-dev/aws-erlang/src
         run: mix run generate.exs erlang $SPEC_PATH $TEMPLATE_PATH $ERLANG_OUTPUT_PATH
       - name: Install a local copy of rebar3
-        run: mix local.rebar rebar3 aws-beam/aws-erlang
+        run: mix local.rebar rebar3 onno-vos-dev/aws-erlang
       - name: Run Erlang tests
         run: ./rebar3 eunit
-        working-directory: aws-beam/aws-erlang
+        working-directory: onno-vos-dev/aws-erlang
       - name: Commit files
         run: |
+          OLD_PATH=$(pwd)
           cd aws/aws-sdk-go/
           git fetch --tags
           LATEST_TAG=$(git describe --tags --abbrev=0)
-          cd ../../
-          cd aws-beam/aws-erlang
+          cd $OLD_PATH
+          cd onno-vos-dev/aws-erlang
           [[ -f latest-tag-aws-sdk-go ]] && LATEST_TAG_BUILT=$(<latest-tag-aws-sdk-go) || LATEST_TAG_BUILT=''
           if [ "$LATEST_TAG_BUILT" != "$LATEST_TAG" ] || [ "$LATEST_TAG_BUILT" == "$LATEST_TAG" ]
           then
-            git config --local user.email "aws-erlang@github.com"
-            git config --local user.name "AWS Erlang"
+            git config --local user.email "actions@github.com"
+            git config --local user.name "GitHub Actions"
             git add src/*
             if [ -n "$(git status --porcelain)" ]
             then
@@ -76,6 +77,6 @@ jobs:
         uses: ad-m/github-push-action@v0.6.0
         with:
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          repository: aws-beam/aws-erlang
+          repository: onno-vos-dev/aws-erlang
           branch: master
-          directory: aws-beam/aws-erlang
+          directory: onno-vos-dev/aws-erlang

--- a/lib/aws_codegen.ex
+++ b/lib/aws_codegen.ex
@@ -90,7 +90,7 @@ defmodule AWS.CodeGen do
         end
       )
 
-    Enum.each(tasks, fn task -> Task.await(task) end)
+    Enum.each(tasks, fn task -> Task.await(task, 60000) end)
   end
 
   defp generate_code(spec, language, endpoints_spec, template_base_path, output_path) do


### PR DESCRIPTION
This PR brings in two additional pipelines: `nightly-elixir` and `nightly-erlang` which consequently will build and push `aws-elixir` and `aws-erlang` both on push to `master` as well as nightly at 00:23 server time. 

The idea here is that I think it's awesome to have auto-generated based on the official AWS SDK GO but it's even more awesome to do this every night and bring any bugfix, new library and other shiny stuff in on a nightly basis and roll out the code accordingly. If any fix is applied to the generator code, one should not have to generate the code yourself and then creating the subequent PR in the `aws-elixir` or `aws-erlang` repo but this should happen automatically :smile: 

This PR by itself will not work as a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) has to be generated and put in place for this to work as the pipeline pushes cross-repos. 

To test this, I've had this running in my forks for the last week or so and it's been working nicely :-) 

You can see it in action here: [scheduled jobs on fork](https://github.com/onno-vos-dev/aws-codegen/actions?query=event%3Aschedule)
With results in aws-elixir here: [onno-vos-dev/aws-elixir/commits/master](https://github.com/onno-vos-dev/aws-elixir/commits/master)
With results in aws-erlang here: [onno-vos-dev/aws-erlang/commits/master](https://github.com/onno-vos-dev/aws-erlang/commits/master)

A few open questions:
* For starters, is this a feature you'd like to see?
* Should the push happen to `master` or to some imaginary `nightly` branch? In the latter, what should the process look like for merging `nightly` into `master`? 

If you feel you'd like to move forward with this PR, I'm happy to try and assist in making sure that the personal_access_token stuff is setup accordingly :+1: 
