### PR TITLE
Support responses with partial content(using the Range request header) where HTTP code 206 is returned.

### DIFF
--- a/priv/rest.erl.eex
+++ b/priv/rest.erl.eex
@@ -171,6 +171,7 @@ handle_response({ok, StatusCode, ResponseHeaders}, SuccessStatusCode, _DecodeBod
   when StatusCode =:= 200;
        StatusCode =:= 202;
        StatusCode =:= 204;
+       StatusCode =:= 206;
        StatusCode =:= SuccessStatusCode ->
     {ok, {StatusCode, ResponseHeaders}};
 handle_response({ok, StatusCode, ResponseHeaders}, _, _DecodeBody) ->
@@ -179,6 +180,7 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, De
   when StatusCode =:= 200;
        StatusCode =:= 202;
        StatusCode =:= 204;
+       StatusCode =:= 206;
        StatusCode =:= SuccessStatusCode ->
     case hackney:body(Client) of
         {ok, <<>>} when StatusCode =:= 200;


### PR DESCRIPTION
When making partial requests using the Range header, to get a chunk of the file, the response HTTP code is 206, but it's not handled as a success code.