### PR TITLE
Avoid bucket in both Path and Host as this causes NoSuchKey errors

### DIFF
--- a/priv/rest.erl.eex
+++ b/priv/rest.erl.eex
@@ -223,12 +223,12 @@ build_host(EndpointPrefix, #{endpoint := Endpoint}, Bucket) ->
     aws_util:binary_join([Bucket, EndpointPrefix, Endpoint], <<".">>).<% else %>
 build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}, undefined) ->
     Endpoint;
-build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}, Bucket) ->
-    <<Bucket/binary, ".", Endpoint/binary>>;
+build_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}, _Bucket) ->
+    <<Endpoint/binary>>;
 build_host(_EndpointPrefix, #{region := <<"local">>}, undefined) ->
     "localhost";
-build_host(_EndpointPrefix, #{region := <<"local">>}, Bucket) ->
-    <<Bucket/binary, ".", "localhost">>;<%= if context.is_global do %>
+build_host(_EndpointPrefix, #{region := <<"local">>}, _Bucket) ->
+    <<"localhost">>;<%= if context.is_global do %>
 build_host(EndpointPrefix, #{endpoint := Endpoint}, undefined) ->
     aws_util:binary_join([EndpointPrefix, Endpoint], <<".">>);
 build_host(EndpointPrefix, #{endpoint := Endpoint}, Bucket) ->
@@ -248,18 +248,22 @@ build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
 
 <%= if AWS.CodeGen.RestService.Context.s3_context?(context) do %>build_url(Host0, Path0, Client, Bucket) ->
     Proto = maps:get(proto, Client),
+    %% Mocks are notoriously bad with host-style requests, just skip it and use path-style for anything local
+    %% At some points once the mocks catch up, we should remove this ugly hack...
+    Host1 = erlang:iolist_to_binary(Host0),
+    IsLocalHost = maps:get(region, Client) =:= <<"local">>,
     Path = case Bucket of
-              undefined ->
-                erlang:iolist_to_binary(Path0);
+              _ when not IsLocalHost andalso Bucket =/= undefined ->
+                erlang:iolist_to_binary(binary:replace(iolist_to_binary(Path0), [Bucket, <<Bucket/binary, "/">>], <<"">>, [global]));
               _ ->
-                erlang:iolist_to_binary(binary:replace(iolist_to_binary(Path0), [Bucket, <<Bucket/binary, "/">>], <<"">>, [global]))
+                erlang:iolist_to_binary(Path0)
             end,
     Host = case Bucket of
-          undefined ->
-            erlang:iolist_to_binary(Host0);
-          _ ->
-            erlang:iolist_to_binary(string:replace(erlang:iolist_to_binary(Host0), <<Bucket/binary, ".">>, <<"">>, all))
-        end,
+             _ when not IsLocalHost andalso Bucket =/= undefined ->
+               erlang:iolist_to_binary(string:replace(Host1, <<Bucket/binary, ".">>, <<"">>, all));
+             _ ->
+              Host1
+           end,
     Port = maps:get(port, Client),
     aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, Path], <<"">>).<% else %>build_url(Host, Path0, Client) ->
     Proto = maps:get(proto, Client),

--- a/priv/rest.erl.eex
+++ b/priv/rest.erl.eex
@@ -252,7 +252,7 @@ build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
               undefined ->
                 erlang:iolist_to_binary(Path0);
               _ ->
-                erlang:iolist_to_binary(string:replace(erlang:iolist_to_binary(Path0), <<Bucket/binary, "/">>, <<"">>, all))
+                erlang:iolist_to_binary(binary:replace(iolist_to_binary(Path0), [Bucket, <<Bucket/binary, "/">>], <<"">>, [global]))
             end,
     Host = case Bucket of
           undefined ->


### PR DESCRIPTION
Considering we use virtual-host style of Host headers since https://github.com/aws-beam/aws-codegen/pull/84 we should not have the host as part of the Path as well. The intention of https://github.com/aws-beam/aws-codegen/pull/84 was to actually strip it but it failed to do so for Paths that did not contain anything but the bucket (such as `aws_s3:list_objects/5`). 

The result is that prior to this change, the Path coming back from `aws_s3:build_url/4` would be: `<<"https://s3.eu-west-1.amazonaws.com:443/kfile.nonprod.eu1.kred.klarna.net">>` whereas the intention of the author (me :smile: ) was to result in a path such as `<<"https://s3.eu-west-1.amazonaws.com:443/">>` since the bucket is already baked into the Host.

This fixes a critical bug which causes ListObjects to essentially not work at all and always returns NoSuchKey errors. 