### PR TITLE
generate structs for post services

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 config :floki, :html_parser, Floki.HTMLParser.FastHtml
 

--- a/lib/aws_codegen.ex
+++ b/lib/aws_codegen.ex
@@ -34,6 +34,7 @@ defmodule AWS.CodeGen do
               protocol: nil,
               signature_version: nil,
               service_id: nil,
+              shapes: [],
               signing_name: nil,
               target_prefix: nil
   end

--- a/lib/aws_codegen/post_service.ex
+++ b/lib/aws_codegen/post_service.ex
@@ -1,12 +1,26 @@
 defmodule AWS.CodeGen.PostService do
   alias AWS.CodeGen.Docstring
   alias AWS.CodeGen.Service
+  alias AWS.CodeGen.Shapes
+  alias AWS.CodeGen.Name
 
   defmodule Action do
     defstruct arity: nil,
               docstring: nil,
               function_name: nil,
+              input: nil,
+              output: nil,
               name: nil
+  end
+
+  defmodule Shape do
+    defstruct name: nil,
+              type: nil,
+              members: [],
+              member: [],
+              enum: [],
+              min: nil,
+              required: []
   end
 
   @configuration %{
@@ -43,7 +57,7 @@ defmodule AWS.CodeGen.PostService do
   def load_context(language, %AWS.CodeGen.Spec{} = spec, endpoints_spec) do
     metadata = spec.api["metadata"]
     actions = collect_actions(language, spec.api, spec.doc)
-
+    shapes = collect_shapes(spec.api)
     endpoint_prefix = metadata["endpointPrefix"]
     endpoint_info = endpoints_spec["services"][endpoint_prefix]
     is_global = not is_nil(endpoint_info) and not Map.get(endpoint_info, "isRegionalized", true)
@@ -79,6 +93,7 @@ defmodule AWS.CodeGen.PostService do
       language: language,
       module_name: spec.module_name,
       protocol: protocol,
+      shapes: shapes,
       signing_name: signing_name,
       signature_version: metadata["signatureVersion"],
       service_id: metadata["serviceId"],
@@ -87,7 +102,7 @@ defmodule AWS.CodeGen.PostService do
   end
 
   defp collect_actions(language, api_spec, doc_spec) do
-    Enum.map(api_spec["operations"], fn {operation, _metadata} ->
+    Enum.map(api_spec["operations"], fn {operation, metadata} ->
       %Action{
         arity: 3,
         docstring:
@@ -95,10 +110,29 @@ defmodule AWS.CodeGen.PostService do
             language,
             doc_spec["operations"][operation]
           ),
-        function_name: AWS.CodeGen.Name.to_snake_case(operation),
+        function_name: Name.to_snake_case(operation),
+        input: Shapes.get_input_shape(metadata),
+        output: Shapes.get_output_shape(metadata),
         name: operation
       }
     end)
     |> Enum.sort(fn a, b -> a.function_name < b.function_name end)
+  end
+
+  defp collect_shapes(api_spec) do
+    api_spec["shapes"]
+    |> Enum.sort(fn {name_a, _}, {name_b, _} -> name_a < name_b end)
+    |> Enum.map(fn {name, shape} ->
+      {name,
+       %Shape{
+         name: name,
+         type: shape["type"],
+         member: shape["member"],
+         members: shape["members"],
+         min: shape["min"],
+         enum: shape["enum"]
+       }}
+    end)
+    |> Enum.into(%{})
   end
 end

--- a/lib/aws_codegen/shapes.ex
+++ b/lib/aws_codegen/shapes.ex
@@ -1,4 +1,5 @@
 defmodule AWS.CodeGen.Shapes do
+  alias AWS.CodeGen.Name
   @moduledoc false
 
   def get_input_shape(operation_spec) do

--- a/lib/aws_codegen/types.ex
+++ b/lib/aws_codegen/types.ex
@@ -1,0 +1,83 @@
+defmodule AWS.CodeGen.Types do
+  alias AWS.CodeGen.PostService.Shape
+  alias AWS.CodeGen.Name
+
+  # Unfortunately, gotta patch over auto-defining types that already exist in Elixir
+
+  def shape_to_type("String", _) do
+    "String.t()"
+  end
+
+  def shape_to_type("string", _) do
+    "String.t()"
+  end
+
+  def shape_to_type("Identifier", _) do
+    "String.t()"
+  end
+
+  def shape_to_type("identifier", _) do
+    "String.t()"
+  end
+
+  def shape_to_type("XmlString" <> _rest, _) do
+    "String.t()"
+  end
+
+  def shape_to_type("NullablePositiveInteger", _) do
+    "nil | non_neg_integer()"
+  end
+
+  def shape_to_type(%Shape{type: type}, _module_name) when type in ["float", "double", "long"] do
+    "float()"
+  end
+
+  def shape_to_type(%Shape{type: "timestamp"}, _module_name) do
+    "non_neg_integer()"
+  end
+
+  def shape_to_type(%Shape{type: "map"}, _module_name) do
+    "map()"
+  end
+
+  def shape_to_type(%Shape{type: "blob"}, _module_name) do
+    "binary()"
+  end
+
+  def shape_to_type(%Shape{type: "string"}, _module_name) do
+    "String.t()"
+  end
+
+  def shape_to_type(%Shape{type: "integer"}, _module_name) do
+    "integer()"
+  end
+
+  def shape_to_type(%Shape{type: "boolean"}, _module_name) do
+    "boolean()"
+  end
+
+  def shape_to_type(%Shape{name: shape_name} = shape, module_name) do
+    raise "missing shape for type #{shape_name} #{inspect(shape, limit: :infinity)}"
+    "#{module_name}.#{Name.to_snake_case(shape_name)}"
+  end
+
+  def shape_to_type(%{"shape" => shape}, module_name, all_shapes) do
+    shape_to_type(shape, module_name, all_shapes)
+  end
+
+  def shape_to_type(shape_name, module_name, all_shapes) do
+    case all_shapes[shape_name] do
+      %Shape{type: "structure"} ->
+        "#{module_name}.#{shape_name}.t()"
+
+      %Shape{type: "list", member: member} ->
+        "[#{shape_to_type(member, module_name, all_shapes)}]"
+
+      nil ->
+        raise "Tried to reference an undefined shape"
+
+      shape ->
+        shape_to_type(shape, module_name)
+    end
+  end
+end

--- a/priv/post.ex.eex
+++ b/priv/post.ex.eex
@@ -35,4 +35,24 @@ defmodule <%= context.module_name %> do
     Request.request_post(client, metadata(), "<%= action.name %>", input, options)
   end
 <% end %>
+
+  <%=  for {_name, shape} <- context.shapes do %>
+    <%=  if shape.type == "structure" do %>
+    defmodule <%= shape.name %> do
+      defstruct [
+        <%= for {name, %{"shape" => _shape}} <- shape.members do %>
+        :<%= AWS.CodeGen.Name.to_snake_case(name) %>,
+        <% end %>
+      ]
+
+      @type t :: %__MODULE__{
+        <%= for {name, %{"shape" => shape}} <- shape.members do %>
+        <%= AWS.CodeGen.Name.to_snake_case(name) %>: <%= AWS.CodeGen.Types.shape_to_type(shape, context.module_name, context.shapes) %>,
+        <% end %>
+      }
+    end
+    <%  end %>
+
+  <%  end %>
+
 end


### PR DESCRIPTION
This code will generate all of the internal modules that are defined by the shapes in the api json. I wouldn't merge this, it takes _forever_ to compile, however, it might be a good starting point for generating input/output types. 