### PR TITLE
Add host prefix to metadata

### DIFF
--- a/lib/aws_codegen/post_service.ex
+++ b/lib/aws_codegen/post_service.ex
@@ -6,6 +6,7 @@ defmodule AWS.CodeGen.PostService do
     defstruct arity: nil,
               docstring: nil,
               function_name: nil,
+              host_prefix: nil,
               name: nil
   end
 
@@ -96,6 +97,7 @@ defmodule AWS.CodeGen.PostService do
             doc_spec["operations"][operation]
           ),
         function_name: AWS.CodeGen.Name.to_snake_case(operation),
+        host_prefix: get_in(operation, ["endpoint", "hostPrefix"]),
         name: operation
       }
     end)

--- a/lib/aws_codegen/post_service.ex
+++ b/lib/aws_codegen/post_service.ex
@@ -88,7 +88,7 @@ defmodule AWS.CodeGen.PostService do
   end
 
   defp collect_actions(language, api_spec, doc_spec) do
-    Enum.map(api_spec["operations"], fn {operation, _metadata} ->
+    Enum.map(api_spec["operations"], fn {operation, metadata} ->
       %Action{
         arity: 3,
         docstring:
@@ -97,7 +97,7 @@ defmodule AWS.CodeGen.PostService do
             doc_spec["operations"][operation]
           ),
         function_name: AWS.CodeGen.Name.to_snake_case(operation),
-        host_prefix: get_in(operation, ["endpoint", "hostPrefix"]),
+        host_prefix: get_in(metadata, ["endpoint", "hostPrefix"]),
         name: operation
       }
     end)

--- a/lib/aws_codegen/rest_service.ex
+++ b/lib/aws_codegen/rest_service.ex
@@ -22,6 +22,7 @@ defmodule AWS.CodeGen.RestService do
               response_header_parameters: [],
               send_body_as_binary?: false,
               receive_body_as_binary?: false,
+              host_prefix: nil,
               language: nil
 
     def method(action) do
@@ -261,6 +262,7 @@ defmodule AWS.CodeGen.RestService do
           collect_response_header_parameters(language, api_spec, operation),
         send_body_as_binary?: Shapes.body_as_binary?(shapes, input_shape),
         receive_body_as_binary?: Shapes.body_as_binary?(shapes, output_shape),
+        host_prefix: get_in(operation_spec, ["endpoint", "hostPrefix"]), 
         language: language
       }
     end)

--- a/lib/aws_codegen/rest_service.ex
+++ b/lib/aws_codegen/rest_service.ex
@@ -262,7 +262,7 @@ defmodule AWS.CodeGen.RestService do
           collect_response_header_parameters(language, api_spec, operation),
         send_body_as_binary?: Shapes.body_as_binary?(shapes, input_shape),
         receive_body_as_binary?: Shapes.body_as_binary?(shapes, output_shape),
-        host_prefix: get_in(operation_spec, ["endpoint", "hostPrefix"]), 
+        host_prefix: get_in(operation_spec, ["endpoint", "hostPrefix"]),
         language: language
       }
     end)

--- a/lib/aws_codegen/spec.ex
+++ b/lib/aws_codegen/spec.ex
@@ -23,7 +23,7 @@ defmodule AWS.CodeGen.Spec do
     api_filename = Keyword.get(opts, :api_filename, "api-2.json")
     doc_filename = Keyword.get(opts, :doc_filename, "docs-2.json")
 
-    api = path |> Path.join(api_filename) |> parse_json
+    api = path |> Path.join(api_filename) |> parse_json()
 
     protocol =
       api["metadata"]["protocol"]

--- a/priv/post.ex.eex
+++ b/priv/post.ex.eex
@@ -6,13 +6,13 @@ defmodule <%= context.module_name %> do
   @moduledoc """
 <%= context.docstring %>
   """
-  <% end%>
+  <% end %>
 
   alias AWS.Client
   alias AWS.Request
 
   def metadata do
-    %AWS.ServiceMetadata{
+    %{
       abbreviation: <%= inspect(context.abbreviation) %>,
       api_version: <%= inspect(context.api_version) %>,
       content_type: <%= inspect(context.content_type) %>,
@@ -32,7 +32,14 @@ defmodule <%= context.module_name %> do
 <%= action.docstring %>
   """<% end %>
   def <%= action.function_name %>(%Client{} = client, input, options \\ []) do
-    Request.request_post(client, metadata(), "<%= action.name %>", input, options)
+    meta =
+      <%= if action.host_prefix do %>
+        metadata() |> Map.put_new(:host_prefix, <%= inspect(action.host_prefix) %>)
+      <% else %>
+        metadata()
+      <% end %>
+
+    Request.request_post(client, meta, "<%= action.name %>", input, options)
   end
 <% end %>
 end

--- a/priv/rest.erl.eex
+++ b/priv/rest.erl.eex
@@ -152,7 +152,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
     Client1 = Client#{service => <<"<%= context.signing_name %>">><%= if context.is_global do %>,
                       region => <<"<%= context.credential_scope %>">><% end %>},
     <%= if context.endpoint_prefix == "s3-control" do %>AccountId = proplists:get_value(<<"x-amz-account-id">>, Headers0),
-    Host = build_host(AccountId, <<"<%= "#{context.host_prefix}#{context.endpoint_prefix}" %>">>, Client1),<% else %><%= if AWS.CodeGen.RestService.Context.s3_context?(context) do %>Host = build_host(<<"<%= "#{context.host_prefix}#{context.endpoint_prefix}" %>">>, Client1, Bucket),<%else %>Host = build_host(<<"<%= "#{context.host_prefix}#{context.endpoint_prefix}" %>">>, Client1),<% end %><% end %>
+    Host = build_host(AccountId, <<"<%= context.endpoint_prefix %>">>, Client1),<% else %><%= if AWS.CodeGen.RestService.Context.s3_context?(context) do %>Host = build_host(<<"<%= context.endpoint_prefix %>">>, Client1, Bucket),<%else %>Host = build_host(<<"<%= context.endpoint_prefix %>">>, Client1),<% end %><% end %>
     URL0 = build_url(Host, Path, Client1<%= if AWS.CodeGen.RestService.Context.s3_context?(context) do %>, Bucket<% end %>),
     URL = aws_request:add_query(URL0, Query),
     AdditionalHeaders = [ {<<"Host">>, Host}

--- a/priv/rest.erl.eex
+++ b/priv/rest.erl.eex
@@ -152,7 +152,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
     Client1 = Client#{service => <<"<%= context.signing_name %>">><%= if context.is_global do %>,
                       region => <<"<%= context.credential_scope %>">><% end %>},
     <%= if context.endpoint_prefix == "s3-control" do %>AccountId = proplists:get_value(<<"x-amz-account-id">>, Headers0),
-    Host = build_host(AccountId, <<"<%= context.endpoint_prefix %>">>, Client1),<% else %><%= if AWS.CodeGen.RestService.Context.s3_context?(context) do %>Host = build_host(<<"<%= context.endpoint_prefix %>">>, Client1, Bucket),<%else %>Host = build_host(<<"<%= context.endpoint_prefix %>">>, Client1),<% end %><% end %>
+    Host = build_host(AccountId, <<"<%= "#{context.host_prefix}#{context.endpoint_prefix}" %>">>, Client1),<% else %><%= if AWS.CodeGen.RestService.Context.s3_context?(context) do %>Host = build_host(<<"<%= "#{context.host_prefix}#{context.endpoint_prefix}" %>">>, Client1, Bucket),<%else %>Host = build_host(<<"<%= "#{context.host_prefix}#{context.endpoint_prefix}" %>">>, Client1),<% end %><% end %>
     URL0 = build_url(Host, Path, Client1<%= if AWS.CodeGen.RestService.Context.s3_context?(context) do %>, Bucket<% end %>),
     URL = aws_request:add_query(URL0, Query),
     AdditionalHeaders = [ {<<"Host">>, Host}

--- a/priv/rest.ex.eex
+++ b/priv/rest.ex.eex
@@ -12,7 +12,7 @@ defmodule <%= context.module_name %> do
   alias AWS.Request
 
   def metadata do
-    %AWS.ServiceMetadata{
+    %{
       abbreviation: <%= inspect(context.abbreviation) %>,
       api_version: <%= inspect(context.api_version) %>,
       content_type: <%= inspect(context.content_type) %>,
@@ -67,7 +67,14 @@ defmodule <%= context.module_name %> do
       )
     <% end %>
 
-    Request.request_rest(client, metadata(), :get, url_path, query_params, headers, nil, options, <%= inspect(action.success_status_code) %>)<% else %>
+    meta =
+      <%= if action.host_prefix do %>
+        metadata() |> Map.put_new(:host_prefix, <%= inspect(action.host_prefix) %>)
+      <% else %>
+        metadata()
+      <% end %>
+
+    Request.request_rest(client, meta, :get, url_path, query_params, headers, nil, options, <%= inspect(action.success_status_code) %>)<% else %>
   def <%= action.function_name %>(%Client{} = client<%= AWS.CodeGen.RestService.function_parameters(action) %>, input, options \\ []) do
     url_path = "<%= AWS.CodeGen.RestService.Action.url_path(action) %>"<%= if length(action.request_header_parameters) > 0 do %>
     {headers, input} =
@@ -104,6 +111,13 @@ defmodule <%= context.module_name %> do
       )
     <% end %>
 
-    Request.request_rest(client, metadata(), <%= AWS.CodeGen.RestService.Action.method(action) %>, url_path, query_params, headers, input, options, <%= inspect(action.success_status_code) %>)<% end %>
+    meta =
+      <%= if action.host_prefix do %>
+        metadata() |> Map.put_new(:host_prefix, <%= inspect(action.host_prefix) %>)
+      <% else %>
+        metadata()
+      <% end %>
+
+    Request.request_rest(client, meta, <%= AWS.CodeGen.RestService.Action.method(action) %>, url_path, query_params, headers, input, options, <%= inspect(action.success_status_code) %>)<% end %>
   end<% end %>
 end

--- a/test/aws_codegen_test.exs
+++ b/test/aws_codegen_test.exs
@@ -62,7 +62,7 @@ defmodule AWS.CodeGenTest do
                  alias AWS.Request
 
                  def metadata do
-                   %AWS.ServiceMetadata{
+                   %{
                      abbreviation: nil,
                      api_version: "2014-06-05",
                      content_type: "application/x-amz-json-1.1",
@@ -89,9 +89,11 @@ defmodule AWS.CodeGenTest do
 
                    query_params = []
 
+                   meta = metadata()
+
                    Request.request_rest(
                      client,
-                     metadata(),
+                     meta,
                      :post,
                      url_path,
                      query_params,
@@ -128,7 +130,7 @@ defmodule AWS.CodeGenTest do
                  alias AWS.Request
 
                  def metadata do
-                   %AWS.ServiceMetadata{
+                   %{
                      abbreviation: nil,
                      api_version: "2014-06-05",
                      content_type: "application/x-amz-json-1.1",
@@ -162,9 +164,11 @@ defmodule AWS.CodeGenTest do
 
                    query_params = []
 
+                   meta = metadata()
+
                    Request.request_rest(
                      client,
-                     metadata(),
+                     meta,
                      :post,
                      url_path,
                      query_params,
@@ -199,7 +203,7 @@ defmodule AWS.CodeGenTest do
                  alias AWS.Request
 
                  def metadata do
-                   %AWS.ServiceMetadata{
+                   %{
                      abbreviation: nil,
                      api_version: "2014-06-05",
                      content_type: "application/x-amz-json-1.1",
@@ -240,9 +244,11 @@ defmodule AWS.CodeGenTest do
                        true
                      )
 
+                   meta = metadata()
+
                    Request.request_rest(
                      client,
-                     metadata(),
+                     meta,
                      :post,
                      url_path,
                      query_params,
@@ -283,7 +289,7 @@ defmodule AWS.CodeGenTest do
                  alias AWS.Request
 
                  def metadata do
-                   %AWS.ServiceMetadata{
+                   %{
                      abbreviation: nil,
                      api_version: "2014-06-05",
                      content_type: "application/x-amz-json-1.1",
@@ -337,14 +343,73 @@ defmodule AWS.CodeGenTest do
                        true
                      )
 
+                   meta = metadata()
+
+                   Request.request_rest(client, meta, :get, url_path, query_params, headers, nil, options, 202)
+                 end
+               end
+               """)
+    end
+
+    test "renders the module with endpoint prefix with host prefix", %{specs: specs} do
+      context = setup_context(:elixir, specs)
+
+      [action | _] = context.actions
+
+      action = %{action | host_prefix: "my-host-prefix."}
+
+      result =
+        %{context | actions: [action]}
+        |> AWS.CodeGen.render("priv/rest.ex.eex")
+        |> IO.iodata_to_binary()
+
+      assert result ==
+               String.trim_leading("""
+               # WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
+               # See https://github.com/aws-beam/aws-codegen for more details.
+
+               defmodule AWS.MobileAnalytics do
+                 alias AWS.Client
+                 alias AWS.Request
+
+                 def metadata do
+                   %{
+                     abbreviation: nil,
+                     api_version: "2014-06-05",
+                     content_type: "application/x-amz-json-1.1",
+                     credential_scope: nil,
+                     endpoint_prefix: "mobileanalytics",
+                     global?: false,
+                     protocol: "rest-json",
+                     service_id: nil,
+                     signature_version: "v4",
+                     signing_name: "mobileanalytics",
+                     target_prefix: nil
+                   }
+                 end
+
+                 def put_events(%Client{} = client, input, options \\\\ []) do
+                   url_path = "/2014-06-05/events"
+
+                   {headers, input} =
+                     [
+                       {"clientContext", "x-amz-Client-Context"},
+                       {"clientContextEncoding", "x-amz-Client-Context-Encoding"}
+                     ]
+                     |> Request.build_params(input)
+
+                   query_params = []
+
+                   meta = metadata() |> Map.put_new(:host_prefix, "my-host-prefix.")
+
                    Request.request_rest(
                      client,
-                     metadata(),
-                     :get,
+                     meta,
+                     :post,
                      url_path,
                      query_params,
                      headers,
-                     nil,
+                     input,
                      options,
                      202
                    )


### PR DESCRIPTION
This makes the host prefix available for use in the Elixir request
module. ~In Erlang, the host prefix is prepended to the endpoint prefix~.

This also removes the usage of a struct for service metadata.