### PR TITLE
Include action on REST calls

### DIFF
--- a/priv/rest.ex.eex
+++ b/priv/rest.ex.eex
@@ -74,7 +74,7 @@ defmodule <%= context.module_name %> do
         metadata()
       <% end %>
 
-    Request.request_rest(client, meta, :get, url_path, query_params, headers, nil, options, <%= inspect(action.success_status_code) %>)<% else %>
+    Request.request_rest(client, meta, "<%= action.name %>", :get, url_path, query_params, headers, nil, options, <%= inspect(action.success_status_code) %>)<% else %>
   def <%= action.function_name %>(%Client{} = client<%= AWS.CodeGen.RestService.function_parameters(action) %>, input, options \\ []) do
     url_path = "<%= AWS.CodeGen.RestService.Action.url_path(action) %>"<%= if length(action.request_header_parameters) > 0 do %>
     {headers, input} =
@@ -118,6 +118,6 @@ defmodule <%= context.module_name %> do
         metadata()
       <% end %>
 
-    Request.request_rest(client, meta, <%= AWS.CodeGen.RestService.Action.method(action) %>, url_path, query_params, headers, input, options, <%= inspect(action.success_status_code) %>)<% end %>
+    Request.request_rest(client, meta, "<%= action.name %>", <%= AWS.CodeGen.RestService.Action.method(action) %>, url_path, query_params, headers, input, options, <%= inspect(action.success_status_code) %>)<% end %>
   end<% end %>
 end

--- a/test/aws_codegen_test.exs
+++ b/test/aws_codegen_test.exs
@@ -94,6 +94,7 @@ defmodule AWS.CodeGenTest do
                    Request.request_rest(
                      client,
                      meta,
+                     \"PutEvents\",
                      :post,
                      url_path,
                      query_params,
@@ -169,6 +170,7 @@ defmodule AWS.CodeGenTest do
                    Request.request_rest(
                      client,
                      meta,
+                     \"PutEvents\",
                      :post,
                      url_path,
                      query_params,
@@ -249,6 +251,7 @@ defmodule AWS.CodeGenTest do
                    Request.request_rest(
                      client,
                      meta,
+                     \"PutEvents\",
                      :post,
                      url_path,
                      query_params,
@@ -345,7 +348,18 @@ defmodule AWS.CodeGenTest do
 
                    meta = metadata()
 
-                   Request.request_rest(client, meta, :get, url_path, query_params, headers, nil, options, 202)
+                   Request.request_rest(
+                     client,
+                     meta,
+                     \"PutEvents\",
+                     :get,
+                     url_path,
+                     query_params,
+                     headers,
+                     nil,
+                     options,
+                     202
+                   )
                  end
                end
                """)
@@ -405,6 +419,7 @@ defmodule AWS.CodeGenTest do
                    Request.request_rest(
                      client,
                      meta,
+                     \"PutEvents\",
                      :post,
                      url_path,
                      query_params,


### PR DESCRIPTION
This extra bit of information is useful in the context of telemetry, specifically OpenTelemetry, as it allow us to adhere to [Semantic Attributes for AWS][1].

To reduce coordination efforts, this change will only affect aws-elixir. A further patch can address aws-erlang to achieve parity.

[1]: https://github.com/open-telemetry/opentelemetry-specification/blob/0a4c6656d1ac1261cfe426b964fd63b1c302877d/specification/trace/semantic_conventions/instrumentation/aws-sdk.md