### PR TITLE
Allow the running of rebar3 edoc to pass without warnings

### DIFF
--- a/lib/aws_codegen/docstring.ex
+++ b/lib/aws_codegen/docstring.ex
@@ -36,6 +36,9 @@ defmodule AWS.CodeGen.Docstring do
     |> fix_long_break_lines()
     |> String.trim_trailing()
     |> String.replace(@two_break_lines, "\n%%\n")
+    |> String.replace(~r/&#39;/, "'")
+    |> String.replace("`AVAILABLE`", "`AVAILABLE'") # aws-sdk-go docs are broken for this, hack it to make the edocs work
+    |> String.replace("`PENDING`", "`PENDING'") # aws-sdk-go docs are broken for this, hack it to make the edocs work
   end
 
   defp split_first_sentence_in_one_line(doc) do
@@ -284,7 +287,7 @@ defmodule AWS.CodeGen.Docstring do
       other ->
         other
     end)
-    |> Floki.raw_html(encode: false)
+    |> Floki.raw_html(encode: true)
   end
 
   @doc """

--- a/test/aws_codegen/docstring_test.exs
+++ b/test/aws_codegen/docstring_test.exs
@@ -215,7 +215,7 @@ defmodule AWS.CodeGen.DocstringTest do
           %% This is a `code' and a multiline is here:
           %%
           %% ```
-          %% puts "hello"
+          %% puts &quot;hello&quot;
           %% '''
           %%
           %% == Section title ==


### PR DESCRIPTION
Fixes: https://github.com/aws-beam/aws-erlang/issues/110

This is a somewhat nasty solution but after fighting with the edoc parser I'm starting to give up on making this pretty. For now this would work and as a temporary solution allows us to publish updated hexdocs to hexdocs.pm again :slightly_smiling_face: 

Downside:
* Docs in Erlang code will look slightly worse such as per example below:
```erlang
%% The forecast file name will match the following conventions:
%%
%% &lt;ForecastExportJobName&gt;_&lt;ExportTimestamp&gt;_&lt;PartNumber&gt;
%%
%% where the &lt;ExportTimestamp&gt; component is in Java SimpleDateFormat
%% (yyyy-MM-ddTHH-mm-ssZ).
```

Upside:
* Edocs can be published again to hexdocs.pm :+1: 