### PR TITLE
Handle 503 responses as service_unavailable and turn it into a retriable error

### DIFF
--- a/priv/rest.erl.eex
+++ b/priv/rest.erl.eex
@@ -216,6 +216,10 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, De
                      end,
             {ok, Result, {StatusCode, ResponseHeaders, Client}}
     end;
+handle_response({ok, StatusCode, _ResponseHeaders, _Client}, _, _DecodeBody)
+  when StatusCode =:= 503 ->
+  %% Retriable error if retries are enabled
+  {error, service_unavailable};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, _, _DecodeBody) ->
     {ok, Body} = hackney:body(Client),
     try


### PR DESCRIPTION
Requires: https://github.com/aws-beam/aws-erlang/pull/124
Fixes: https://github.com/aws-beam/aws-erlang/issues/123

Results in the following diff (for example `aws_s3.erl`):
```
diff --git a/src/aws_s3.erl b/src/aws_s3.erl
index 45a81ed..43b4fd5 100644
--- a/src/aws_s3.erl
+++ b/src/aws_s3.erl
@@ -8003,6 +8003,10 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}, SuccessStatusCode, De
                      end,
             {ok, Result, {StatusCode, ResponseHeaders, Client}}
     end;
+handle_response({ok, StatusCode, _ResponseHeaders, _Client}, _, _DecodeBody)
+  when StatusCode =:= 503 ->
+  %% Retriable error if retries are enabled
+  {error, service_unavailable};
 handle_response({ok, StatusCode, ResponseHeaders, Client}, _, _DecodeBody) ->
     {ok, Body} = hackney:body(Client),
     try
```

