### PR TITLE
Remove all usages of maps:get(<something>, Client)

### DIFF
--- a/priv/post.erl.eex
+++ b/priv/post.erl.eex
@@ -82,6 +82,6 @@ build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).
 <% end %>
 build_url(Host, Client) ->
-    Proto = maps:get(proto, Client),
-    Port = maps:get(port, Client),
+    Proto = aws_client:proto(Client),
+    Port = aws_client:port(Client),
     aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>], <<"">>).

--- a/priv/rest.erl.eex
+++ b/priv/rest.erl.eex
@@ -272,11 +272,11 @@ build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
     aws_util:binary_join([EndpointPrefix, Region, Endpoint], <<".">>).<% end %><% end %><% end %>
 
 <%= if AWS.CodeGen.RestService.Context.s3_context?(context) do %>build_url(Host0, Path0, Client, Bucket) ->
-    Proto = maps:get(proto, Client),
+    Proto = aws_client:proto(Client),
     %% Mocks are notoriously bad with host-style requests, just skip it and use path-style for anything local
     %% At some points once the mocks catch up, we should remove this ugly hack...
     Host1 = erlang:iolist_to_binary(Host0),
-    IsLocalHost = maps:get(region, Client) =:= <<"local">>,
+    IsLocalHost = aws_client:region(Client) =:= <<"local">>,
     Path = case Bucket of
               _ when not IsLocalHost andalso Bucket =/= undefined ->
                 erlang:iolist_to_binary(binary:replace(iolist_to_binary(Path0), [Bucket, <<Bucket/binary, "/">>], <<"">>, [global]));
@@ -289,11 +289,11 @@ build_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
              _ ->
               Host1
            end,
-    Port = maps:get(port, Client),
+    Port = aws_client:port(Client),
     aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, Path], <<"">>).<% else %>build_url(Host, Path0, Client) ->
-    Proto = maps:get(proto, Client),
+    Proto = aws_client:proto(Client),
     Path = erlang:iolist_to_binary(Path0),
-    Port = maps:get(port, Client),
+    Port = aws_client:port(Client),
     aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, Path], <<"">>).<% end %>
 
 -spec encode_payload(undefined | map()) -> binary().


### PR DESCRIPTION
Follow up of: https://github.com/aws-beam/aws-erlang/pull/135