### PR TITLE
Improvements to erlang docs

### DIFF
--- a/lib/aws_codegen/docstring.ex
+++ b/lib/aws_codegen/docstring.ex
@@ -283,15 +283,14 @@ defmodule AWS.CodeGen.Docstring do
           end
         end
 
-      {"a", attrs, children} = html_node ->
+      {"a", attrs, children} ->
         case Enum.find(attrs, fn {attr, _} -> attr == "href" end) do
           {_, href} ->
             text = Floki.text(children)
-
             if text == href do
               "[#{href}]"
             else
-              html_node
+              "#{text}: #{href}"
             end
 
           nil ->

--- a/lib/aws_codegen/docstring.ex
+++ b/lib/aws_codegen/docstring.ex
@@ -274,7 +274,13 @@ defmodule AWS.CodeGen.Docstring do
         if String.contains?(text, "\n") do
           "\n```\n#{String.trim_leading(text, "\n")}'''#{@two_break_lines}"
         else
-          "`#{text}'"
+          ## ex_doc blows up on these sorts of things as it sees them as a reference to a function.
+          ## Just ignore them as they refer to aws-sdk-go based implementations and we don't really care about that
+          if String.ends_with?(text, "()") do
+            ""
+          else
+            "`#{text}'"
+          end
         end
 
       {"a", attrs, children} = html_node ->

--- a/test/aws_codegen/docstring_test.exs
+++ b/test/aws_codegen/docstring_test.exs
@@ -211,7 +211,7 @@ defmodule AWS.CodeGen.DocstringTest do
           """
           %% @doc A short description.
           %%
-          %% This is a <a href="https://foo.bar">link</a>.
+          %% This is a link: https://foo.bar.
           %% This is a `code' and a multiline is here:
           %%
           %% ```


### PR DESCRIPTION
- Ensure `<code>` tags that contain references to AWS SDK GO functions are ignored as they blow up ex_doc
- Improve links and ensure more links are rendered in the docs

Example OLD:
```erlang
%% To verify that all parts have been removed and prevent getting charged for
%% the part storage, you should call the ListParts API operation and ensure
%% that the parts list is empty.
```

Example NEW:
```erlang
%% To verify that all parts have been removed and prevent getting charged for
%% the part storage, you should call the ListParts:
%% https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html API
%% operation and ensure that the parts list is empty.
```