### PR TITLE
Add identifier to reserved types and fix reserved_type references to use correct reference rather than ghost-type

### DIFF
--- a/lib/aws_codegen/types.ex
+++ b/lib/aws_codegen/types.ex
@@ -53,7 +53,7 @@ defmodule AWS.CodeGen.Types do
 
   defp update_acc_with_types(acc, type, types, context) do
     if reserved_type(type) do
-      module_name = String.downcase(String.replace(context.module_name, "AWS.", ""))
+      module_name = String.downcase(String.replace(context.module_name, ["aws_", "AWS."], ""))
       Map.put(acc, "#{module_name}_#{type}", types)
     else
       Map.put(acc, type, types)
@@ -194,7 +194,7 @@ defmodule AWS.CodeGen.Types do
   end
 
   defp reserved_type(type) do
-    type == "node" || type == "term" || type == "function" || type == "reference"
+    type == "node" || type == "term" || type == "function" || type == "reference" || type == "identifier"
   end
 
   def function_argument_type(:elixir, action) do


### PR DESCRIPTION
This broke the AWS-Erlang & AWS-Elixir nightly builds which went unnoticed. 

Example:
```erlang
%% Example:
%% quicksight_identifier() :: #{
%%   <<"Identity">> => string()
%% }
-type quicksight_identifier() :: #{binary() => any()}.

%% Example:
%% topic_sort_clause() :: #{
%%   <<"Operand">> => quicksight_identifier(),
%%   <<"SortDirection">> => list(any())
%% }
-type topic_sort_clause() :: #{binary() => any()}.
```

```elixir
  @typedoc """

  ## Example:

      quicksight_identifier() :: %{
        "Identity" => String.t()
      }

  """
  @type quicksight_identifier() :: %{String.t() => any()}
  
  @typedoc """

  ## Example:

      topic_sort_clause() :: %{
        "Operand" => quicksight_identifier(),
        "SortDirection" => list(any())
      }

  """
  @type topic_sort_clause() :: %{String.t() => any()}
```