### PR TITLE
uri_encode_path in aws_bedrock_runtime

### DIFF
--- a/priv/post.erl.eex
+++ b/priv/post.erl.eex
@@ -90,7 +90,7 @@ request(Client, Action, Input, Options) ->
     Input = Input0,
 <% end %>
     Payload = <%= context.encode %>,
-    SignedHeaders = aws_request:sign_request(Client1, <<"POST">>, URL, Headers, Payload),
+    SignedHeaders = aws_request:sign_request(Client1, <<"POST">>, URL, Headers, Payload<%= if context.module_name == "aws_apigatewaymanagementapi" or String.contains?(context.module_name, "aws_bedrock") do %>, [{uri_encode_path, true}]<% else %><% end %>),
     Response = hackney:request(post, URL, SignedHeaders, Payload, Options),
     handle_response(Response).
 

--- a/priv/rest.erl.eex
+++ b/priv/rest.erl.eex
@@ -231,7 +231,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
 
     MethodBin = aws_request:method_to_binary(Method),
-    SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload<%= if context.module_name in ["aws_apigatewaymanagementapi", "aws_bedrock_runtime"] do %>, [{uri_encode_path, true}]<% else %><% end %>),
+    SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload<%= if context.module_name == "aws_apigatewaymanagementapi" or String.contains?(context.module_name, "aws_bedrock") do %>, [{uri_encode_path, true}]<% else %><% end %>),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).

--- a/priv/rest.erl.eex
+++ b/priv/rest.erl.eex
@@ -231,7 +231,7 @@ do_request(Client, Method, Path, Query, Headers0, Input, Options, SuccessStatusC
     Headers1 = aws_request:add_headers(AdditionalHeaders, Headers0),
 
     MethodBin = aws_request:method_to_binary(Method),
-    SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload<%= if context.module_name == "aws_apigatewaymanagementapi" do %>, [{uri_encode_path, true}]<% else %><% end %>),
+    SignedHeaders = aws_request:sign_request(Client1, MethodBin, URL, Headers1, Payload<%= if context.module_name in ["aws_apigatewaymanagementapi", "aws_bedrock_runtime"] do %>, [{uri_encode_path, true}]<% else %><% end %>),
     Response = hackney:request(Method, URL, SignedHeaders, Payload, Options),
     DecodeBody = not proplists:get_value(receive_body_as_binary, Options),
     handle_response(Response, SuccessStatusCode, DecodeBody).


### PR DESCRIPTION
Required to fix: https://github.com/aws-beam/aws-erlang/issues/161